### PR TITLE
upgrade to json.net 7

### DIFF
--- a/Source/.nuget/Bogus.nuspec
+++ b/Source/.nuget/Bogus.nuspec
@@ -56,7 +56,7 @@
     <tags>fake bogus poco data generator database seed values test-data test data</tags>
     <dependencies>
       <group targetFramework="net40">
-          <dependency id="Newtonsoft.Json" />
+          <dependency id="Newtonsoft.Json" version="[7,8)" />
       </group>
     </dependencies>
   </metadata>

--- a/Source/Bogus.Tests/Bogus.Tests.csproj
+++ b/Source/Bogus.Tests/Bogus.Tests.csproj
@@ -38,8 +38,8 @@
       <HintPath>..\packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/Source/Bogus.Tests/packages.config
+++ b/Source/Bogus.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="3.3.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="NUnit" version="2.6.3" targetFramework="net451" />
 </packages>

--- a/Source/Bogus/Bogus.csproj
+++ b/Source/Bogus/Bogus.csproj
@@ -33,8 +33,8 @@
     <DocumentationFile>bin\Release\Bogus.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -104,6 +104,8 @@
     <EmbeddedResource Include="data\fr_CA.locale.json" />
     <EmbeddedResource Include="data\uk.locale.json" />
     <EmbeddedResource Include="data\en_IE.locale.json" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/Bogus/Properties/AssemblyInfo.cs
+++ b/Source/Bogus/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyrightAttribute("Brian Chavez © 2015")]
 [assembly: AssemblyVersionAttribute("3.0.0.2")]
 [assembly: AssemblyFileVersion("3.0.0.2")]
-[assembly: AssemblyInformationalVersion("3.0.0.2 built on 7/12/2015 6:55:22 AM UTC")]
+[assembly: AssemblyInformationalVersion("3.0.0.2 built on 7/21/2015 2:42:49 PM UTC")]
 [assembly: AssemblyTrademark("MIT License")]
 [assembly: AssemblyDescriptionAttribute("http://www.github.com/bchavez/Bogus")]
 [assembly: ComVisible(false)]

--- a/Source/Bogus/packages.config
+++ b/Source/Bogus/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net4" />
 </packages>

--- a/Source/Builder/Builder.csproj
+++ b/Source/Builder/Builder.csproj
@@ -54,8 +54,8 @@
       <HintPath>..\packages\morelinq.1.1.1\lib\net35\MoreLinq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Source/Builder/packages.config
+++ b/Source/Builder/packages.config
@@ -5,7 +5,7 @@
   <package id="FluentPath" version="1.1.0" targetFramework="net451" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net451" />
   <package id="morelinq" version="1.1.1" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="NuGet.Core" version="2.8.5" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Implements #2 by upgrading and fixating the nuspec file for Bogus to be constraint to the major version of 7 from `Json.NET`