### PR TITLE
import vs env variables when running from vanilla cmd console

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,9 @@
+@ECHO OFF
+
+IF NOT DEFINED DevEnvDir (
+	CALL "%vs120comntools%\vsvars32.bat"
+)
+
 set version="3.0.0.2"
 msbuild source\Builder\Builder.csproj
 Source\Builder\bin\Debug\fb.exe Source\Builder\bin\Debug\Builder.dll -c:ProjectBuildTask -p:Version="%version%"

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,12 @@
 @ECHO OFF
 
 IF NOT DEFINED DevEnvDir (
-	CALL "%vs120comntools%\vsvars32.bat"
+	IF DEFINED vs120comntools ( 
+		CALL "%vs120comntools%\vsvars32.bat"
+	)
+	IF DEFINED vs140comntools ( 
+		CALL "%vs140comntools%\vsvars32.bat"
+	)
 )
 
 set version="3.0.0.2"


### PR DESCRIPTION
Small fix so that you can run build.bat from a vanilla console, and it turns ECHO off so commands are not echo'd.