### PR TITLE
Fixed lastname and empty list exception

### DIFF
--- a/Source/Bogus.Tests/NameTests.cs
+++ b/Source/Bogus.Tests/NameTests.cs
@@ -48,6 +48,13 @@ namespace Bogus.Tests
         }
 
         [Test]
+        public void should_be_able_to_get_locale_full_name()
+        {
+            var n = new Name("ru");
+            n.FindName().Should().Contain(" ");
+        }
+
+        [Test]
         public void should_be_able_to_get_any_name_with_options()
         {
             name.FindName(firstName: "cowboy")

--- a/Source/Bogus.Tests/NameTests.cs
+++ b/Source/Bogus.Tests/NameTests.cs
@@ -109,7 +109,7 @@ namespace Bogus.Tests
         {
             var n = new Name("ru");
 
-            n.LastName().Should().Be("Анастасия");
+            n.LastName().Should().Be("Киселева");
         }
     }
 }

--- a/Source/Bogus/DataSets/Name.cs
+++ b/Source/Bogus/DataSets/Name.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Newtonsoft.Json.Linq;
-
-namespace Bogus.DataSets
+﻿namespace Bogus.DataSets
 {
     /// <summary>
     /// Methods for generating names
@@ -61,9 +58,9 @@ namespace Bogus.DataSets
 
                 if( gender == Gender.Male )
                 {
-                    return GetRandomArrayItem("male_first_name");
+                    return GetRandomArrayItem("male_last_name");
                 }
-                return GetRandomArrayItem("female_first_name");
+                return GetRandomArrayItem("female_last_name");
             }
 
             return GetRandomArrayItem("last_name");

--- a/Source/Bogus/Database.cs
+++ b/Source/Bogus/Database.cs
@@ -51,7 +51,7 @@ namespace Bogus
             var path = string.Format("{0}.{1}.{2}", locale, category, key);
             var jtoken = Data.Value.SelectToken(path);
 
-            if( jtoken != null )
+            if( jtoken != null && jtoken.HasValues )
             {
                 return jtoken;
             }


### PR DESCRIPTION
There were copy-paste bug with first_name and last_name picking.
Also FindName throwed exception on non-English locales due to lack of suffixes/postfixes defined.
Funny that unit test checked first name and last name the same. Now should be OK.