### PR TITLE
fix error: System.IndexOutOfRangeException in Commerce.Department

### DIFF
--- a/Source/Bogus/DataSets/Commerce.cs
+++ b/Source/Bogus/DataSets/Commerce.cs
@@ -14,11 +14,14 @@ namespace Bogus.DataSets
             var num = max;
             if( !returnMax )
             {
-                 num = this.Random.Number(max);
+                do
+                {
+                    num = this.Random.Number(max);
+                } while (num == 0);
             }
 
             var cats = Categories(num);
-            if( num > 1 )
+            if (num > 1)
             {
                 return string.Format("{0} & {1}", string.Join(", ", cats.Take(cats.Length - 1)),
                     cats.Last());


### PR DESCRIPTION
You can get exception if you try this:

```
public class TestClass
{
	public string Value { get; set; }
}
[Test]
public void TestFaker()
{
	var faker = new Faker<TestClass>();
	faker.RuleFor(x => x.Value, faker1 => faker1.Random.Word());
	foreach (var item in faker.Generate(1000))
	{
		Debug.WriteLine(item.Value);
	}
}
```