### PR TITLE
Add new Ipv6 generator to Bogus

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## v7.1.7
 * `Faker<T>.AssertConfigurationIsValid` to help in unit testing scenarios.
-* 
+* Add `Internet.Ipv6` method to generate IPv6 addresses.
 
 ## v7.1.6
 * Added `f => f.Commerce` on `Faker`.

--- a/Source/Bogus.Tests/InternetTests.cs
+++ b/Source/Bogus.Tests/InternetTests.cs
@@ -78,6 +78,12 @@ namespace Bogus.Tests
         }
 
         [Test]
+        public void can_get_a_random_ipv6_address()
+        {
+            internet.Ipv6().Should().Be("da23:9c4c:e0c4:2dd7:e3c4:a896:17f2:55b2");
+        }
+
+        [Test]
         public void can_get_html_color()
         {
             internet.Color().Should().Be("#4d0e68");

--- a/Source/Bogus/DataSets/Internet.cs
+++ b/Source/Bogus/DataSets/Internet.cs
@@ -134,6 +134,16 @@ namespace Bogus.DataSets
         }
 
         /// <summary>
+        /// Generates a random IPv6 address.
+        /// </summary>
+        /// <returns></returns>
+        public string Ipv6()
+        {
+            var bytes = Random.Bytes(16);
+            return $"{bytes[0]:x}{bytes[1]:x}:{bytes[2]:x}{bytes[3]:x}:{bytes[4]:x}{bytes[5]:x}:{bytes[6]:x}{bytes[7]:x}:{bytes[8]:x}{bytes[9]:x}:{bytes[10]:x}{bytes[11]:x}:{bytes[12]:x}{bytes[13]:x}:{bytes[14]:x}{bytes[15]:x}";
+        }
+
+        /// <summary>
         /// Gets a random mac address
         /// </summary>
         public string Mac()


### PR DESCRIPTION
Add new Ipv6 generator to Bogus. Feature parity with faker.js. Prep new `7.1.7` release.