### PR TITLE
Fixes #41 implements implicit operator on Faker[T]. :muscle:

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## v11.0.2
+* New Feature: Allow implicit and explicit type casts: `Order o = orderFaker` and `var o = (Order)orderFaker` without having to call `orderFaker.Generate()`.
+
 ## v11.0.1
 * Added `IndexGlobal` alias for `UniqueIndex`.
 * Added `IndexFaker` for uniqueness in Faker[T] lifetime.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/dxa14myphnlbplc6?svg=true)](https://ci.appveyor.com/project/bchavez/bogus)  [![Twitter](https://img.shields.io/twitter/url/https/github.com/bchavez/Bogus.svg?style=social)](https://twitter.com/intent/tweet?text=Simple and Sane Fake Data Generator for .NET:&amp;amp;url=https%3A%2F%2Fgithub.com%2Fbchavez%2FBogus) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bchavez/Bogus)
-<img src="https://raw.githubusercontent.com/bchavez/Bogus/master/Docs/logo.png" align='right' /> 
+[![Build status](https://ci.appveyor.com/api/projects/status/dxa14myphnlbplc6?svg=true)](https://ci.appveyor.com/project/bchavez/bogus)  [![Twitter](https://img.shields.io/twitter/url/https/github.com/bchavez/Bogus.svg?style=social)](https://twitter.com/intent/tweet?text=Simple and Sane Fake Data Generator for .NET:&amp;amp;url=https%3A%2F%2Fgithub.com%2Fbchavez%2FBogus) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bchavez/Bogus) <a href="http://www.jetbrains.com/resharper"><img src="http://i61.tinypic.com/15qvwj7.jpg" alt="ReSharper" title="ReSharper"></a>
+<img src="https://raw.githubusercontent.com/bchavez/Bogus/master/Docs/logo.png" align='right' />
 
 Bogus for .NET/C#
 ======================
 
 Project Description
 -------------------
-A simple and sane fake data generator for C# and .NET. Bogus is a C# port of [faker.js](https://github.com/marak/Faker.js/)
-and inspired by FluentValidation's syntax sugar.
+Hello. I'm your host **[Brian Chavez](https://github.com/bchavez)** ([twitter](https://twitter.com/bchavez)). Bogus is a simple and sane fake data generator for C# and .NET. Bogus is a C# port of [`faker.js`](https://github.com/marak/Faker.js/)
+and inspired by [`FluentValidation`](https://github.com/JeremySkinner/FluentValidation)'s syntax sugar.
 
-**Bogus** will help you load databases, UI and apps with fake data for your testing needs.
+**Bogus** will help you load databases, UI and apps with fake data for your testing needs. If you like **Bogus** star :star: the repository and show your friends! :smile:
 
 
 ### Download & Install
@@ -433,6 +433,30 @@ public void Handlebar()
 */
 ```
 
+#### Implicit and Explicit Type Conversion
+You can also use implicit type conversion to make your code look cleaner.
+
+```csharp
+var orderFaker = new Faker<Order>()
+                     .RuleFor(o => o.OrderId, f => f.IndexVariable++)
+                     .RuleFor(o => o.Item, f => f.Commerce.Product())
+                     .RuleFor(o => o.Quantity, f => f.Random.Number(1,3));
+
+Order testOrder = orderFaker;
+testOrder.Dump();
+
+/* OUTPUT:
+{
+  "OrderId": 0,
+  "Item": "Computer",
+  "Quantity": 2
+}
+*/
+
+//Explicit works too!
+var anotherOrder = (Order)orderFaker;
+```
+
 Building
 --------
 * Download the source code.
@@ -478,4 +502,4 @@ A big thanks to GitHub and all contributors:
 * [JvanderStad](https://github.com/JvanderStad)
 * [Giuseppe Dimauro](https://github.com/gdimauro)
 
-<a href="http://www.jetbrains.com/resharper"><img src="http://i61.tinypic.com/15qvwj7.jpg" alt="ReSharper" title="ReSharper"></a>
+

--- a/Source/Bogus.Tests/FluentTests.cs
+++ b/Source/Bogus.Tests/FluentTests.cs
@@ -180,6 +180,36 @@ namespace Bogus.Tests
             action.ShouldThrow<ArgumentException>();
         }
 
+        [Test]
+        public void implicit_operator_test()
+        {
+            var orderFaker = new Faker<Order>()
+                .RuleFor(o => o.OrderId, f => f.IndexVariable++)
+                .RuleFor(o => o.Quantity, f => f.Random.Number(1, 3))
+                .RuleFor(o => o.Item, f => f.Commerce.Product());
+
+            Order testOrder1 = orderFaker;
+            Order testOrder2 = orderFaker;
+            Order testOrder3 = orderFaker;
+
+            testOrder1.Dump();
+            testOrder2.Dump();
+            testOrder3.Dump();
+
+            var threeOrders = new[] {testOrder1, testOrder2, testOrder3};
+            threeOrders.Select(o => o.Item).Should().ContainInOrder("Computer", "Tuna", "Soap");
+            threeOrders.Select(o => o.Quantity).Should().ContainInOrder(2, 3, 1);
+
+            var testOrders = Enumerable.Range(1, 3)
+                .Select(x => (Order)orderFaker)
+                .ToArray();
+
+            testOrders.Dump();
+
+            testOrders.Select(o => o.Item).Should().ContainInOrder("Chicken", "Gloves", "Mouse");
+            testOrders.Select(o => o.Quantity).Should().ContainInOrder(1, 2, 3);
+        }
+
         public class Issue47
         {
             public string Foo { get; set; }
@@ -195,6 +225,7 @@ namespace Bogus.Tests
             public int OrderId { get; set; }
             public string Item { get; set; }
             public int Quantity { get; set; }
+
         }
 
         public enum Gender

--- a/Source/Bogus/Faker[T].cs
+++ b/Source/Bogus/Faker[T].cs
@@ -28,6 +28,11 @@ namespace Bogus
 #pragma warning restore 1591
 
         /// <summary>
+        /// The current locale.
+        /// </summary>
+        public string Locale { get; set; }
+
+        /// <summary>
         /// Creates a Faker with default 'en' locale.
         /// </summary>
         public Faker() : this("en", null)
@@ -411,9 +416,13 @@ namespace Bogus
             return result;
         }
 
+
         /// <summary>
-        /// The current locale.
+        /// Provides implicit type conversion from Faker[T] to T. IE: Order testOrder = faker;
         /// </summary>
-        public string Locale { get; set; }
+        public static implicit operator T(Faker<T> faker)
+        {
+            return faker.Generate();
+        }
     }
 }


### PR DESCRIPTION
Fixes #41, implements implicit operator on `Faker<T>`. :muscle:

The following is now possible on `Faker<T>`:

#### Implicit and Explicit Type Conversion

```csharp
var orderFaker = new Faker<Order>()
                     .RuleFor(o => o.OrderId, f => f.IndexVariable++)
                     .RuleFor(o => o.Item, f => f.Commerce.Product())
                     .RuleFor(o => o.Quantity, f => f.Random.Number(1,3));

Order testOrder = orderFaker;
testOrder.Dump();

/* OUTPUT:
{
  "OrderId": 0,
  "Item": "Computer",
  "Quantity": 2
}
*/

//Explicit works too!
var anotherOrder = (Order)orderFaker;
```