### PR TITLE
Remove whitespace when publishing Bogus to NuGet

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,8 @@
 * Add parameter for including `Currency` fund codes (BOV, CLF, COU, MXV, UYI).
 * Fixed minor issue in `Person.Email` having duplicate names.
 * Helper method: `f.PickRandomWithout(ExcludeItem1, ExcludeItem2)` added.
-* Helper method: `f.PickRandom("cat", "dog", "fish")` added. 
+* Helper method: `f.PickRandom("cat", "dog", "fish")` added.
+* Performance: 40% reduction in Bogus' DLL size and memory footprint by removing whitespace in **Json** data files.  
 
 ## v15.0.3
 * Added `f => f.Rant` to generate random user content like product reviews.

--- a/Source/Builder/build.fsx
+++ b/Source/Builder/build.fsx
@@ -194,11 +194,26 @@ Target "setup-snk"(fun _ ->
     XmlPokeInnerText BogusProject.ProjectFile "/Project/PropertyGroup/SignAssembly" "true"
 )
 
+open Newtonsoft.Json
+open Newtonsoft.Json.Linq
+
+Target "compress-data" (fun _ ->
+   traceHeader "Compressing data folder and removing whitespace"
+   
+   for file in !!(BogusProject.Folder @@ "data" @@ "*.json") do
+      traceFAKE "Compressing %s" file
+      let jsonText = ReadFileAsString file
+      JObject.Parse(jsonText).ToString(Formatting.None)
+      |>
+      WriteStringToFile false file
+)
 
 "Clean"
     ==> "restore"
     ==> "BuildInfo"
-        
+
+"compress-data"
+   =?> ("nuget", BuildContext.IsTaggedBuild)
 
 //build systems, order matters
 "BuildInfo"


### PR DESCRIPTION
Removing whitespace (indents/tabs/newlines) in locale `Bogus/data/*.json` files ***reduces*** Bogus' DLL and memory footprint about 40%.

Huge win for performance by stripping whitespace before we publish to **NuGet**.

However, we still want to keep whitespace when doing development to aid readability.

This PR does just that.

:briefcase: :necktie: ***["Taking care of business every day... Taking care of business every way..."](https://www.youtube.com/watch?v=mmwic9kFx2c)***


