### PR TITLE
Added Faker<T> Rules(Action<Faker, T> setActions) to IRuleSet

### DIFF
--- a/Source/Bogus.Tests/RuleSetTests.cs
+++ b/Source/Bogus.Tests/RuleSetTests.cs
@@ -135,6 +135,25 @@ namespace Bogus.Tests
             results.Should().OnlyContain(c => c.Description == "overridden");
         }
 
+        [Fact]
+        public void should_be_able_to_use_rules_with_ruleset()
+        {
+            var testCustomers = new Faker<Customer>()
+                .RuleSet("Good",
+                    (set) =>
+                    {
+                        set.Rules((f, c) =>
+                        {
+                            c.Description = f.Lorem.Sentence();
+                            c.Description = "overridden";
+                        });
+                    });
+
+            var results = testCustomers.Generate(5, "Good");
+
+            results.Should().OnlyContain(c => c.Description == "overridden");
+        }
+
 
         public class EmptyObject
         {

--- a/Source/Bogus.Tests/StrictModeTests.cs
+++ b/Source/Bogus.Tests/StrictModeTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Bogus.Tests
 {
@@ -57,5 +59,41 @@ namespace Bogus.Tests
             Action act2 = () => faker2.AssertConfigurationIsValid();
             act2.ShouldThrow<ValidationException>();
         }
+
+        [Fact]
+        public void cannot_use_rules_with_strictmode_inside_rulesets()
+        {
+           const string myset = "myset";
+
+           var faker = new Faker<Examples.Order>()
+              .RuleSet(myset, set =>
+                 {
+                    set.Rules((f, o) =>
+                       {
+                          o.Quantity = f.Random.Number(1, 4);
+                          o.Item = f.Commerce.Product();
+                          o.OrderId = 25;
+                       });
+                    set.StrictMode(true);
+                 });
+
+           Action act = () => faker.AssertConfigurationIsValid();
+           act.ShouldThrow<ValidationException>();
+
+           var faker2 = new Faker<Examples.Order>()
+              .RuleSet(myset, set =>
+                 {
+                    set.StrictMode(true);
+                    set.Rules((f, o) =>
+                       {
+                          o.Quantity = f.Random.Number(1, 4);
+                          o.Item = f.Commerce.Product();
+                          o.OrderId = 25;
+                       });
+                 });
+
+           Action act2 = () => faker2.AssertConfigurationIsValid();
+           act2.ShouldThrow<ValidationException>();
+      }
     }
 }

--- a/Source/Bogus/IRuleSet.cs
+++ b/Source/Bogus/IRuleSet.cs
@@ -52,5 +52,12 @@ namespace Bogus
         /// Creates a rule for a property.
         /// </summary>
         Faker<T> RuleFor<TProperty>(Expression<Func<T, TProperty>> property, TProperty value);
+
+        /// <summary>
+        /// Gives you a way to specify multiple rules inside an action
+        /// without having to call RuleFor multiple times. Note: StrictMode
+        /// must be false since property rules cannot be individually checked.
+        /// </summary>
+        Faker<T> Rules(Action<Faker, T> setActions);
     }
 }


### PR DESCRIPTION
 I prefer the Rules((f,c))=>{}) style of adding actions in a batch. I added that to the interface to accommodate this style.