### PR TITLE
Re-enable .NET Standard 1.3 targeting.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,5 @@
 ## v21.0.1 
+* Re-enabled **.NET Standard 1.3** targeting.
 * Added `Gender` field to `Person`. Deterministic sequences may have changed.
 * Added `Randomizer.Bool(weight)` to generate weighted boolean values of true.
 * Italian `CodiceFiscale()` extension method added. Extends `Person` and `Finance`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and inspired by [`FluentValidation`](https://github.com/JeremySkinner/FluentVali
 ```
 Install-Package Bogus
 ```
-Minimum Requirements: **.NET Standard 2.0** or **.NET Framework 4.0**.
+Minimum Requirements: **.NET Standard 1.3** or **.NET Framework 4.0**.
 
 ##### Projects That Use Bogus
 

--- a/Source/Bogus/Bogus.csproj
+++ b/Source/Bogus/Bogus.csproj
@@ -5,7 +5,7 @@
     </PackageReleaseNotes>
     <Version>0.0.0-localbuild</Version>
     <Authors>Brian Chavez</Authors>
-    <TargetFrameworks>net40;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.3;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <CodeAnalysisRuleSet>Default.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -30,7 +30,10 @@
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);STANDARD</DefineConstants>
+    <DefineConstants>$(DefineConstants);STANDARD;STANDARD20</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <DefineConstants>$(DefineConstants);STANDARD;STANDARD13</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="data\*.locale.bson" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
@@ -41,5 +44,9 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/Source/Bogus/Bson/Bson.cs
+++ b/Source/Bogus/Bson/Bson.cs
@@ -149,7 +149,7 @@ namespace Bogus.Bson
                   break;
                ms.WriteByte(buf);
             }
-            return Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Position);
+            return Encoding.UTF8.GetString(ms.ToArray(), 0, (int)ms.Position);
          }
       }
 
@@ -241,7 +241,7 @@ namespace Bogus.Bson
 
          var bw = new BinaryWriter(ms);
          bw.Write((Int32)(dms.Position + 4 + 1));
-         bw.Write(dms.GetBuffer(), 0, (int)dms.Position);
+         bw.Write(dms.ToArray(), 0, (int)dms.Position);
          bw.Write((byte)0);
       }
 

--- a/Source/Bogus/Database.cs
+++ b/Source/Bogus/Database.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Bogus.Bson;
+using Bogus.Platform;
 
 namespace Bogus
 {
@@ -24,7 +25,7 @@ namespace Bogus
       /// </summary>
       public static string[] GetAllLocales()
       {
-         var asm = typeof(Database).Assembly;
+         var asm = typeof(Database).GetAssembly();
 
          return asm.GetManifestResourceNames()
             .Where(name => name.EndsWith(".locale.bson"))
@@ -46,7 +47,7 @@ namespace Bogus
 
       internal static BObject InitLocale(string locale)
       {
-         var asm = typeof(Database).Assembly;
+         var asm = typeof(Database).GetAssembly();
          var resourceName = $"Bogus.data.{locale}.locale.bson";
 
          using( var s = asm.GetManifestResourceStream(resourceName) )

--- a/Source/Bogus/Extensions/ExtensionsForString.cs
+++ b/Source/Bogus/Extensions/ExtensionsForString.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Text;
 

--- a/Source/Bogus/Platform/ExtensionsForType.cs
+++ b/Source/Bogus/Platform/ExtensionsForType.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.IO;
 using System.Reflection;
 
 namespace Bogus.Platform
@@ -7,21 +8,31 @@ namespace Bogus.Platform
    {
       public static T GetCustomAttributeX<T>(this Type type) where T : Attribute
       {
-#if STANDARD
+#if   STANDARD20
          return type.GetCustomAttribute<T>();
+#elif STANDARD13
+         return type.GetTypeInfo().GetCustomAttribute<T>();
 #else
          return Attribute.GetCustomAttribute(type, typeof(T)) as T;
 #endif
       }
-   }
 
-   internal class EnumValueAttribute : Attribute
-   {
-      public string Value { get; }
-
-      public EnumValueAttribute(string value)
+      public static bool IsEnum(this Type type)
       {
-         this.Value = value;
+#if STANDARD13
+         return type.GetTypeInfo().IsEnum;
+#else
+         return type.IsEnum;
+#endif
+      }
+
+      public static Assembly GetAssembly(this Type type)
+      {
+#if STANDARD13
+         return type.GetTypeInfo().Assembly;
+#else
+         return type.Assembly;
+#endif
       }
    }
 }

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using Bogus.Bson;
 using Bogus.DataSets;
+using Bogus.Platform;
 
 namespace Bogus
 {
@@ -474,7 +475,7 @@ namespace Bogus
       public T Enum<T>(params T[] exclude) where T : struct
       {
          var e = typeof(T);
-         if( !e.IsEnum )
+         if( !e.IsEnum() )
             throw new ArgumentException("When calling Enum<T>() with no parameters T must be an enum.");
 
          var selection = System.Enum.GetNames(e);


### PR DESCRIPTION
Re-enables **.NET Standard 1.3** targeting in **Bogus**.

Cutting `v21` release after this merge passes tests.

//cc @Mpdreamz 

Reference #100, #101, #94.

:car: :blue_car: ***["Let the good times roll..."](https://www.youtube.com/watch?v=7BDBzgHXf64)***