### PR TITLE
Bugfix category not working for images

### DIFF
--- a/Source/Bogus/DataSets/Images.cs
+++ b/Source/Bogus/DataSets/Images.cs
@@ -41,7 +41,7 @@ namespace Bogus.DataSets
             proto = "https://";
          }
          var url = $"{proto}lorempixel.com/{width}/{height}";
-         if( string.IsNullOrWhiteSpace(category) )
+         if( !string.IsNullOrWhiteSpace(category) )
             url += $"/{category}";
          if( randomize )
             url += $"?{this.Random.Number()}";


### PR DESCRIPTION
When using the Image API it is actually not possible to add the category because the if statement is wrong.