### PR TITLE
Improve speed of DataSet.ParseTokens() 

### DIFF
--- a/Source/Bogus/DataSet.cs
+++ b/Source/Bogus/DataSet.cs
@@ -143,14 +143,15 @@ namespace Bogus
          return Random.Replace(tokenResult);
       }
 
+      private static readonly Regex parseTokensRegex = new Regex("\\#{(.*?)\\}", RegexOptions.Compiled);
+
       /// <summary>
       /// Recursive parse the tokens in the string.
       /// </summary>
       /// <param name="value">The value.</param>
       private string ParseTokens(string value)
       {
-         var regex = new Regex("\\#{(.*?)\\}");
-         var cityResult = regex.Replace(value,
+         var cityResult = parseTokensRegex.Replace(value,
             x =>
                {
                   BArray result;


### PR DESCRIPTION
Profiling an application that uses Bogus to generate thousands of entities indicates a lot of time being spent recreating the regular expression whenever `DataSet.ParseTokens()` is called.

By caching and compiling the regular expression, performance should improve considerably. According to the [official documentation](https://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex(v=vs.110).aspx):

> The Regex class is immutable (read-only) and thread safe. Regex objects can be created on any thread and shared between threads. 