### PR TITLE
Generate random numbers based on a Normal Distribution (Gaussian)

### DIFF
--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -121,7 +121,76 @@ namespace Bogus
          return result;
       }
 
+      // Coefficients used in Acklam's Inverse Normal Cumulative Distribution function.
+      private static readonly double[] AklmasCoefficientA =
+         {-39.696830d, 220.946098d, -275.928510d, 138.357751d, -30.664798d, 2.506628d};
 
+      private static readonly double[] AklamsCoefficientB =
+         {-54.476098d, 161.585836d, -155.698979d, 66.801311d, -13.280681d};
+      private static readonly double[] AklamsCoefficientC =
+         {-0.007784894002d, -0.32239645d, -2.400758d, -2.549732d, 4.374664d, 2.938163d};
+
+      private static readonly double[] AklamsCoefficientD = { 0.007784695709d, 0.32246712d, 2.445134d, 3.754408d };
+
+      // Break-Points used in Aklam's Inverse Normal Cumulative Distribution function.
+      private const double AklamsLowBreakPoint = 0.02425d;
+      private const double AklamsHighBreakPoint = 1.0d - AklamsLowBreakPoint;
+
+      /// <summary>
+      /// This algorithm follows Peter J Acklam's Inverse Normal Cumulative Distribution function.
+      /// Reference: P.J. Acklam, "An algorithm for computing the inverse normal cumulative distribution function," 2010
+      /// </summary>
+      /// <param name="probability"></param>
+      /// <returns>
+      /// A double between 0.0 and 1.0
+      /// </returns>
+      private static double InverseCumulativeStandardNormalDistribution(double probability)
+      {
+
+         // Rational approximation for lower region of distirbution
+         if (probability < AklamsLowBreakPoint)
+         {
+            double q = Math.Sqrt(-2 * Math.Log(probability));
+            return (((((AklamsCoefficientC[0] * q + AklamsCoefficientC[1]) * q + AklamsCoefficientC[2]) * q + AklamsCoefficientC[3]) * q +
+                     AklamsCoefficientC[4]) * q + AklamsCoefficientC[5]) /
+                   ((((AklamsCoefficientD[0] * q + AklamsCoefficientD[1]) * q + AklamsCoefficientD[2]) * q + AklamsCoefficientD[3]) * q + 1);
+         }
+
+         // Rational approximation for upper region of distribution
+         if (AklamsHighBreakPoint < probability)
+         {
+            double q = Math.Sqrt(-2 * Math.Log(1 - probability));
+            return -(((((AklamsCoefficientC[0] * q + AklamsCoefficientC[1]) * q + AklamsCoefficientC[2]) * q + AklamsCoefficientC[3]) * q +
+                      AklamsCoefficientC[4]) * q + AklamsCoefficientC[5]) /
+                   ((((AklamsCoefficientD[0] * q + AklamsCoefficientD[1]) * q + AklamsCoefficientD[2]) * q + AklamsCoefficientD[3]) * q + 1);
+         }
+
+         // Rational approximation for central region of disribution
+         {
+            double q = probability - 0.5d;
+            double r = q * q;
+            return (((((AklmasCoefficientA[0] * r + AklmasCoefficientA[1]) * r + AklmasCoefficientA[2]) * r + AklmasCoefficientA[3]) * r +
+                     AklmasCoefficientA[4]) * r + AklmasCoefficientA[5]) * q /
+                   (((((AklamsCoefficientB[0] * r + AklamsCoefficientB[1]) * r + AklamsCoefficientB[2]) * r + AklamsCoefficientB[3]) * r +
+                     AklamsCoefficientB[4]) * r + 1);
+         }
+      }
+
+      /// <summary>
+      /// Generate a random double, based on the specified normal distribution.
+      /// </summary>
+      /// <param name="mean">Mean value of the normal distribution</param>
+      /// <param name="standardDeviation">Standard deviation of the normal distribution</param>
+      public double DoubleFromNormalDistribution(double mean, double standardDeviation)
+      {
+         //lock any seed access, for thread safety.
+         lock (Locker.Value)
+         {
+            double p = InverseCumulativeStandardNormalDistribution(localSeed.NextDouble());
+            return (p * standardDeviation) + mean;
+         }
+      }
+      
       /// <summary>
       /// Get a random double, between 0.0 and 1.0.
       /// </summary>
@@ -153,6 +222,16 @@ namespace Bogus
       }
 
       /// <summary>
+      /// Generate a random decimal, based on the specified normal distribution.
+      /// </summary>
+      /// <param name="mean">Mean average of the normal distribution</param>
+      /// <param name="standardDeviation">Standard deviation of the normal distribution</param>
+      public decimal DecimalFromNormalDistribution(double mean, double standardDeviation)
+      {
+         return Convert.ToDecimal(DoubleFromNormalDistribution(mean, standardDeviation));
+      }
+
+      /// <summary>
       /// Get a random float, between 0.0 and 1.0
       /// </summary>
       /// <param name="min">Minimum, default 0.0</param>
@@ -160,6 +239,16 @@ namespace Bogus
       public float Float(float min = 0.0f, float max = 1.0f)
       {
          return Convert.ToSingle(Double()) * (max - min) + min;
+      }
+
+      /// <summary>
+      /// Generate a random float, based on the specified normal distribution.
+      /// </summary>
+      /// <param name="mean">Mean average of the normal distribution</param>
+      /// <param name="standardDeviation">Standard deviation of the normal distribution</param>
+      public float FloatFromNormalDistribution(double mean, double standardDeviation)
+      {
+         return Convert.ToSingle(DoubleFromNormalDistribution(mean, standardDeviation));
       }
 
       /// <summary>
@@ -204,6 +293,16 @@ namespace Bogus
       public int Int(int min = int.MinValue, int max = int.MaxValue)
       {
          return this.Number(min, max);
+      }
+
+      /// <summary>
+      /// Generate a random int, based on the specified normal distribution.
+      /// </summary>
+      /// <param name="mean">Mean average of the normal distribution</param>
+      /// <param name="standardDeviation">Standard deviation of the normal distribution</param>
+      public int IntFromNormalDistribution(double mean, double standardDeviation)
+      {
+         return Convert.ToInt32(DoubleFromNormalDistribution(mean, standardDeviation));
       }
 
       /// <summary>


### PR DESCRIPTION
Bogus already has excellent methods for generating random numbers, but these numbers are all, by design, evenly distributed across the whole range of min to max.

In some cases, this even distribution will result in generating data that is not realistic. As an example, if we wanted to generate random data to be used for “Height of a person”, we would currently get an equal number of short, average and tall people being generated. But if we know so properties of the data we want to generate (for example, the US the average height of a male is 175.7cm with a standard deviation of 10cm), it would be great to be able to generate random data points that when analysed, matched the average and standard deviation, meaning we’d have far less extremely short and extremely tall people, which would reflect realistic data.

This could also be used for fields such as product prices, ages and so forth. It’s often more common to have most values falling with a certain range, and less items having extreme values as the tail of the min and max.

I think it would make Bogus even more useful to have this ability. although Bogus is not designed for generating statistical data, the addition of this method is very simple and gives the option of much more realistic data being generated if it's required.

Therefore, I’ve added some methods, prefixed with “FromNormalDistribution” to allow you to specify the mean and standard deviation instead of a min and max.

This is my first ever pull request, so if I'm doing anything wrong, please let me know! Always willing to learn and do this the correct and polite way. :)
