### PR TITLE
Use cached delegates to set property values rather than SetValue

### DIFF
--- a/Source/Benchmark/BenchGenerate.cs
+++ b/Source/Benchmark/BenchGenerate.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Exporters;
+using Bogus;
+
+namespace Benchmark
+{
+   [MarkdownExporter, MemoryDiagnoser]
+   public class BenchGenerate
+   {
+      public class Project
+      {
+         public long Id { get; set; }
+         public string Name { get; set; }
+         public string Description { get; set; }
+      }
+
+      private static Faker<Project> FakerDefault { get; set; }
+      private static Faker<Project> FakerCustom { get; set; }
+      private static Faker<Project> FakerWithRules { get; set; }
+      private static Faker<Project> FakerWithRulesComplex { get; set; }
+
+      [GlobalSetup]
+      public void Setup()
+      {
+         FakerDefault = new Faker<Project>().UseSeed(1337);
+         FakerCustom = new Faker<Project>()
+            .CustomInstantiator(f=> new Project())
+            .UseSeed(1337);
+         FakerWithRules = new Faker<Project>()
+            .CustomInstantiator(f=> new Project())
+            .RuleFor(p=>p.Id, f => f.IndexGlobal)
+            .UseSeed(1337);
+         FakerWithRulesComplex = new Faker<Project>()
+            .CustomInstantiator(f=> new Project())
+            .RuleFor(p=>p.Id, f => f.IndexGlobal)
+            .RuleFor(p => p.Name, f => f.Person.Company.Name + f.UniqueIndex.ToString())
+            .RuleFor(p => p.Description, f => f.Lorem.Paragraphs(3))
+            .UseSeed(1337);
+      }
+
+//      [Benchmark]
+      public void Generate_Default()
+      {
+         var projects = FakerDefault.Generate(10_000).ToList();
+      }
+      
+//      [Benchmark]
+      public void Generate_CustomInstantiator()
+      {
+         var projects = FakerDefault.Generate(10_000).ToList();
+      }
+      
+      [Benchmark]
+      public void Generate_WithRules()
+      {
+         var projects = FakerWithRules.Generate(10_000).ToList();
+      }
+      
+      //[Benchmark]
+      public void Generate_WithRulesComplex()
+      {
+         var projects = FakerWithRulesComplex.Generate(10_000).ToList();
+      }
+      
+//      [Benchmark]
+      public void Constructor()
+      {
+         var projects = Enumerable.Range(0, 10_000).Select(i => new Project {Id = i}).ToList();
+      }
+   }
+}

--- a/Source/Benchmark/Program.cs
+++ b/Source/Benchmark/Program.cs
@@ -2,11 +2,11 @@
 
 namespace Benchmark
 {
-    class Program
-    {
-        static void Main()
-        {
-            BenchmarkRunner.Run<BenchStringFill>();
-        }
-    }
+   class Program
+   {
+      static void Main()
+      {
+         BenchmarkRunner.Run<BenchGenerate>();
+      }
+   }
 }

--- a/Source/Bogus/Extensions/ExtensionsForPropertyInfo.cs
+++ b/Source/Bogus/Extensions/ExtensionsForPropertyInfo.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+
+namespace Bogus.Extensions
+{
+   public static class ExtensionsForPropertyInfo
+   {
+      private static readonly MethodInfo GenericSetterCreationMethod = 
+         typeof(ExtensionsForPropertyInfo).GetMethod(nameof(CreateSetterGeneric), BindingFlags.Static | BindingFlags.NonPublic);
+
+      public static Action<T, object> CreateSetterOld<T>(this PropertyInfo property)
+      {
+         return (i, v) => property.SetValue((object)i, v, null);
+      }
+      public static Action<T, object> CreateSetter<T>(this PropertyInfo property)
+      {
+         if (property == null) throw new ArgumentNullException(nameof(property));
+
+         var setter = property.GetSetMethod();
+         if (setter == null) throw new ArgumentException("The specified property does not have a public setter.");
+
+         var genericHelper = GenericSetterCreationMethod.MakeGenericMethod(property.DeclaringType, property.PropertyType);
+         return (Action<T, object>)genericHelper.Invoke(null, new object[] { setter });
+      }
+
+      private static Action<T, object> CreateSetterGeneric<T, V>(MethodInfo setter) where T : class
+      {
+         var setterTypedDelegate = 
+#if STANDARD
+               (Action<T, V>) setter.CreateDelegate(typeof(Action<T, V>))
+#else
+               (Action<T, V>) Delegate.CreateDelegate(typeof(Action<T, V>), setter)
+#endif
+         ;
+         var setterDelegate = (Action<T, object>)((T instance, object value) => { setterTypedDelegate(instance, (V)value); });
+         return setterDelegate;
+      } 
+
+   }
+}

--- a/Source/Bogus/Extensions/ExtensionsForPropertyInfo.cs
+++ b/Source/Bogus/Extensions/ExtensionsForPropertyInfo.cs
@@ -8,10 +8,6 @@ namespace Bogus.Extensions
       private static readonly MethodInfo GenericSetterCreationMethod = 
          typeof(ExtensionsForPropertyInfo).GetMethod(nameof(CreateSetterGeneric), BindingFlags.Static | BindingFlags.NonPublic);
 
-      public static Action<T, object> CreateSetterOld<T>(this PropertyInfo property)
-      {
-         return (i, v) => property.SetValue((object)i, v, null);
-      }
       public static Action<T, object> CreateSetter<T>(this PropertyInfo property)
       {
          if (property == null) throw new ArgumentNullException(nameof(property));

--- a/Source/Bogus/Faker[T].cs
+++ b/Source/Bogus/Faker[T].cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Text;
+using Bogus.Extensions;
 
 namespace Bogus
 {
@@ -53,6 +55,8 @@ namespace Bogus
       protected internal readonly Dictionary<string, FinalizeAction<T>> FinalizeActions = new Dictionary<string, FinalizeAction<T>>(StringComparer.OrdinalIgnoreCase);
       protected internal Dictionary<string, Func<Faker, T>> CreateActions = new Dictionary<string, Func<Faker, T>>(StringComparer.OrdinalIgnoreCase);
       protected internal readonly Dictionary<string, MemberInfo> TypeProperties;
+      protected internal readonly Dictionary<string, Action<T, object>> TypePropertiesSetters = new Dictionary<string, Action<T, object>>(StringComparer.OrdinalIgnoreCase);
+      
       protected internal Dictionary<string, bool> StrictModes = new Dictionary<string, bool>();
       protected internal bool? IsValid;
       protected internal string currentRuleSet = Default;
@@ -526,8 +530,6 @@ namespace Bogus
             throw MakeValidationException(vr ?? ValidateInternal(ruleSets));
          }
 
-         var typeProps = TypeProperties;
-
          lock( Randomizer.Locker.Value )
          {
             //Issue 57 - Make sure you generate a new context
@@ -543,23 +545,7 @@ namespace Bogus
                {
                   foreach( var action in populateActions.Values )
                   {
-                     typeProps.TryGetValue(action.PropertyName, out MemberInfo member);
-                     var valueFactory = action.Action;
-                     if( valueFactory is null ) continue; // An .Ignore() rule.
-
-                     if( member != null )
-                     {
-                        var prop = member as PropertyInfo;
-                        prop?.SetValue(instance, valueFactory(FakerHub, instance), null);
-
-                        var field = member as FieldInfo;
-                        field?.SetValue(instance, valueFactory(FakerHub, instance));
-                     }
-                     else // member would be null if this was an RuleForObject.
-                     {
-                        //Invoke this if this is a basic rule which does not select a property or a field.
-                        var outputValue = valueFactory(FakerHub, instance);
-                     }
+                     PopulateProperty(instance, action);
                   }
                }
             }
@@ -574,6 +560,42 @@ namespace Bogus
          }
       }
 
+      private readonly object _setterCreateLock = new object();
+      private void PopulateProperty(T instance, PopulateAction<T> action)
+      {
+         var valueFactory = action.Action;
+         if (valueFactory is null) return;
+         
+         var value = valueFactory(FakerHub, instance);
+         
+         if (TypePropertiesSetters.TryGetValue(action.PropertyName, out var setter))
+         {
+            setter(instance, value);
+            return;
+         }
+         
+         if (!TypeProperties.TryGetValue(action.PropertyName, out var member)) return;
+         if (member == null) return;
+
+         lock (_setterCreateLock)
+         {
+            if (TypePropertiesSetters.TryGetValue(action.PropertyName, out setter))
+            {
+               setter(instance, value);
+               return;
+            }
+
+            if (member is PropertyInfo prop) 
+               setter = prop.CreateSetter<T>();
+            // TODO FieldInfo will need to rely on ILEmit to create a delegate 
+            else if (member is FieldInfo field)
+               setter = (i, v) => field?.SetValue(i, v);
+            if (setter == null) return;
+               
+            TypePropertiesSetters.Add(action.PropertyName, setter);
+            setter(instance, value);
+         }
+      }
       /// <summary>
       /// When <seealso cref="StrictMode"/> is enabled, checks if all properties or fields of <typeparamref name="T"/> have
       /// rules defined. Returns true if all rules are defined, false otherwise.


### PR DESCRIPTION
Using the following Fake context to generate `10,000` items:

```csharp
FakerWithRules = new Faker<Project>()
    .CustomInstantiator(f=> new Project())
    .RuleFor(p=>p.Id, f => f.IndexGlobal)
    .UseSeed(1337);
```

Old (SetValue):

|             Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|--------:|----------:|
| Generate_WithRules | 6.770 ms | 0.0624 ms | 0.0584 ms | 265.6250 | 109.3750 | 31.2500 |   1.55 MB |


New (Cached setter delegate):

|             Method |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|--------:|--------:|----------:|
| Generate_WithRules | 4.046 ms | 0.0251 ms | 0.0235 ms | 164.0625 | 93.7500 | 31.2500 | 960.09 KB |

