### PR TITLE
.editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root=true
+
+[*.cs]
+trim_trailing_whitespace=true
+insert_final_newline=true
+
+[*]
+indent_style = space
+indent_size = 3
+
+[*.{fs,fsx}]
+indent_style = space
+indent_size = 4
+
+[*.{md,markdown,json,js,csproj,fsproj,targets}]
+indent_style = space
+indent_size = 2
+


### PR DESCRIPTION
Will work in Rider and VisualStudio (roslyn) out of the box.

Will help those of us with different editor defaults to maintain consistency. `3 spaces` is not that common 😸 