### PR TITLE
Add Visual Studio SourceLink compatibility.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## v24.3.2
+* Add SourceLink compatibility with Visual Studio 2017.
+
 ## v24.3.1
 * `tr` - Turkish locale first/last names updated. Lorem data set updated. Thanks ahmetcanaydemir!
 * Added `f.Image.PicsumUrl` (https://picsum.photos) service as faster alternative to Lorem Pixel. 

--- a/Source/Bogus/Bogus.csproj
+++ b/Source/Bogus/Bogus.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A simple and sane data generator for populating objects that supports different locales. A delightful port of the famed faker.js and inspired by FluentValidation. Use Bogus to create UIs with fake data or seed databases. Get started by using Faker class or a DataSet directly.</Description>
     <PackageReleaseNotes>
@@ -21,6 +21,10 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/bchavez/Bogus</RepositoryUrl>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <!--Source Link Settings-->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>false</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);STANDARD;STANDARD20</DefineConstants>
@@ -33,6 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Roslynator.Analyzers" Version="1.9.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />


### PR DESCRIPTION
Hopefully this makes debugging **Bogus** easier for everyone.

Not a big fan of adding *beta* stuff to **Bogus** but it's a developer dependency; so it should be okay I guess.

Comparing `Bogus.0.0.677-ci.nupkg` and `Bogus.24.3.1.nupkg`:

* Adds about `61 KB` to the total **NuGet** package size.

---

Only real diff between `.nupkg`s is the commit attribute in the `.nuspec` file and `42 KB` PDBs in each TFM output folder.

```diff
diff --git "a/R:\\Bogus.24.3.1\\Bogus.nuspec" "b/R:\\Bogus.0.0.677-ci\\Bogus.nuspec"
index 50922dc..8e8139e 100644
--- "a/R:\\Bogus.24.3.1\\Bogus.nuspec"
+++ "b/R:\\Bogus.0.0.677-ci\\Bogus.nuspec"
@@ -32,20 +35,10 @@
 * Added `nullWeight` parameter to `.OrNull()` extension method for weighted generation of null values.
 * Added new `.OrDefault()` extension method. Thanks @anorborg!

 Full History Here: https://github.com/bchavez/Bogus/blob/master/HISTORY.md</releaseNotes>
     <tags>fake bogus poco data generator database seed values test-data test tdd testing faker .net EF</tags>
-    <repository type="git" url="https://github.com/bchavez/Bogus" />
+    <repository type="git" url="https://github.com/bchavez/Bogus" commit="f5fb8721076fb14ccefa7d9724b226d5e5720f7b" />
     <dependencies>
       <group targetFramework=".NETFramework4.0" />
       <group targetFramework=".NETStandard1.3">
```

:car: :police_car: :rotating_light: ***["Drive it like you stole it..."](https://www.youtube.com/watch?v=dd00Qh9yZUg)***