### PR TITLE
Add PickRandomOrDefault method.

### DIFF
--- a/Source/Bogus.Tests/FluentTests.cs
+++ b/Source/Bogus.Tests/FluentTests.cs
@@ -394,6 +394,15 @@ namespace Bogus.Tests
       }
 
       [Fact]
+      public void can_pick_random_item_or_default()
+      {
+         var numbers = Enumerable.Range(1, 3).Select(i => i);
+         var faker = new Faker();
+         var n = faker.PickRandomOrDefault(numbers);
+         n.Should().BeOneOf(1, 2, 3, default);
+      }
+
+      [Fact]
       public void can_generate_forever()
       {
          var orderFaker = new Faker<Order>()

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -240,6 +240,15 @@ namespace Bogus
       }
 
       /// <summary>
+      /// Picks a random item of T or default(T).
+      /// </summary>
+      /// <returns></returns>
+      public T PickRandomItemOrDefault<T>(T item)
+      {
+         return this.PickRandom(new T[] { item, default });
+      }
+
+      /// <summary>
       /// Helper to pick random subset of elements out of the list.
       /// </summary>
       /// <param name="amountToPick">amount of elements to pick of the list.</param>

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -242,7 +242,6 @@ namespace Bogus
       /// <summary>
       /// Picks a random item of T or default(T).
       /// </summary>
-      /// <returns></returns>
       public T PickRandomItemOrDefault<T>(T item)
       {
          return this.PickRandom(new T[] { item, default });


### PR DESCRIPTION
In many cases you have data with takes things like `int?`. For example, with Entity Framework nullable foreign keys.

This new method makes it easier to write rules which will randomly pick an int or null.

```csharp
EmployeeFaker = new Faker<EmployeeEntity>()
    .UseSeed(4445)
    .Rules((f, o) =>
    {
        // CustomerId is int?.
        o.CustomerId = f.PickRandomOrDefault(f.PickRandom(Contacts))?.Id;
    });

Employees = InventoryServerFaker.Generate(200);
```

This way, you get a random `customer.Id`, or `null`.