### PR TITLE
Fixes #253 Adds Support for RuleFor(string) and Ignore(string)

### DIFF
--- a/Source/Bogus.Tests/GitHubIssues/Issue134.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue134.cs
@@ -49,7 +49,7 @@ namespace Bogus.Tests.GitHubIssues
             var memberName = parts[0].Trim();
             var handlebarRule = parts[1].Trim();
 
-            this.RuleFor(memberName, f => f.Parse($"{handlebarRule}"));
+            this.RuleForInternal(memberName, f => f.Parse($"{handlebarRule}"));
          }
 
          return this;

--- a/Source/Bogus.Tests/GitHubIssues/Issue253.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue253.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Bogus.Tests.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Bogus.Tests.GitHubIssues
+{
+   public class Issue253 : SeededTest
+   {
+      [Fact]
+      public void can_use_advanced_namespace_rulefor_string()
+      {
+         var orderFaker = new Faker<Order>()
+            .RuleFor(nameof(Order.OrderId), f => f.IndexVariable++)
+            .RuleFor(nameof(Order.Quantity), f => f.Random.Number(1, 3))
+            .RuleFor(nameof(Order.Item), f => f.Commerce.Product());
+
+         var order = orderFaker.Generate();
+
+         order.OrderId.Should().Be(0);
+         order.Quantity.Should().Be(2);
+         order.Item.Should().Be("Computer");
+      }
+
+      [Fact]
+      public void rulefor_a_field_that_doesnt_exist_throws()
+      {
+         var orderFaker = new Faker<Order>()
+            .StrictMode(true)
+            .RuleFor(nameof(Order.OrderId), f => f.IndexVariable++)
+            .RuleFor(nameof(Order.Quantity), f => f.Random.Number(1, 3))
+            .RuleFor(nameof(Order.Item), f => f.Commerce.Product());
+         
+
+         Action act  = () => orderFaker.RuleFor("fffff", f => f.Random.Number());
+
+         act.ShouldThrow<ArgumentException>();
+      }
+
+      [Fact]
+      public void ignoring_a_field_that_doesnt_exist_throws()
+      {
+         var orderFaker = new Faker<Order>()
+            .StrictMode(true)
+            .RuleFor(nameof(Order.OrderId), f => f.IndexVariable++)
+            .RuleFor(nameof(Order.Quantity), f => f.Random.Number(1, 3))
+            .RuleFor(nameof(Order.Item), f => f.Commerce.Product());
+
+         orderFaker.Ignore(nameof(Order.Item));
+
+         var o = orderFaker.Generate();
+
+         o.Item.Should().BeNull();
+
+         Action act = () => orderFaker.RuleFor("hhhhh", f => f.Random.Number());
+
+         act.ShouldThrow<ArgumentException>();
+      }
+   }
+}


### PR DESCRIPTION
Adds support for Faker<T>.RuleFor("prop", ...) and Faker<T>.Ignore("prop") where "prop" is a property or field name on `T`. This is helpful in situations where it might be necessary to set up a rule for non-public members; such as `protected` members.

Mostly renamed the existing `protected virtual RuleFor(string)` to `protected virutal RuleForInternal(string)`.

Then added `public virtual RuleFor(string)` which forwards calls to `RuleForInternal`; but before it does so, ensures that the underlying member exists (from the point of view of the `IBinder`).

After looking at the existing code; I found `.Ignore` checks the existence of the members on `T` at `.Ignore` invocation time.  Considering that we already do this for `.Ignore`, I added the same precondition constraint to `.RuleFor(string)` as well.

Basically, the member must exist when calling `.RuleFor(string)` or `.Ignore(string)` for consistency. Plus, it sets up a strong condition at development time to ensure developers are writing valid rules; instead of silently failing at runtime due to no type-safety through string.

//cc @SuricateCan @nickdodd79 
