### PR TITLE
Added ability to generate random IPv4 and IPv6 System.Net.IPEndPoints

### DIFF
--- a/Source/Bogus.Tests/GitHubIssues/PullRequest261.cs
+++ b/Source/Bogus.Tests/GitHubIssues/PullRequest261.cs
@@ -1,0 +1,34 @@
+﻿using System.Net;
+using Bogus.DataSets;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bogus.Tests.GitHubIssues
+{
+   public class PullRequest261 : SeededTest
+   {
+      private readonly ITestOutputHelper console;
+
+      public PullRequest261(ITestOutputHelper console)
+      {
+         this.console = console;
+      }
+
+      [Fact]
+      public void can_generate_ipv4_endpoint()
+      {
+         var i = new Internet();
+         var ep = i.IpEndPoint();
+         ep.ToString().Should().Be("218.35.156.76:2333");
+      }
+
+      [Fact]
+      public void can_generate_ipv6_endpoint()
+      {
+         var i = new Internet();
+         var ep = i.Ipv6EndPoint();
+         ep.ToString().Should().Be("[da23:9c4c:e0c4:2dd7:e3c4:a896:17f2:55b2]:45956");
+      }
+   }
+}

--- a/Source/Bogus/DataSets/Internet.cs
+++ b/Source/Bogus/DataSets/Internet.cs
@@ -188,7 +188,7 @@ namespace Bogus.DataSets
       public IPEndPoint IpEndPoint()
       {
          var address = this.IpAddress();
-         var port = this.Random.Int( IPEndPoint.MinPort + 1, IPEndPoint.MaxPort);
+         var port = this.Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort);
          return new IPEndPoint(address, port);
       }
 
@@ -200,7 +200,7 @@ namespace Bogus.DataSets
       {
          var address = this.Ipv6Address();
          var port = this.Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort);
-         return new IPEndPoint(address,port);
+         return new IPEndPoint(address, port);
       }
 
       private UserAgentGenerator userAgentGenerator;

--- a/Source/Bogus/DataSets/Internet.cs
+++ b/Source/Bogus/DataSets/Internet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using Bogus.Extensions;
 using Bogus.Vendor;
@@ -163,6 +164,28 @@ namespace Bogus.DataSets
          var bytes = Random.Bytes(16);
          return
             $"{bytes[0]:x}{bytes[1]:x}:{bytes[2]:x}{bytes[3]:x}:{bytes[4]:x}{bytes[5]:x}:{bytes[6]:x}{bytes[7]:x}:{bytes[8]:x}{bytes[9]:x}:{bytes[10]:x}{bytes[11]:x}:{bytes[12]:x}{bytes[13]:x}:{bytes[14]:x}{bytes[15]:x}";
+      }
+
+      /// <summary>
+      /// Gets a random IPv4 IPEndPoint.
+      /// </summary>
+      /// <returns>A random IPv4 IPEndPoint.</returns>
+      public IPEndPoint IpEndPoint()
+      {
+         return new IPEndPoint(
+            new IPAddress(Random.Bytes(4)),
+            Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort));
+      }
+
+      /// <summary>
+      /// Gets a random IPv6 IPEndPoint.
+      /// </summary>
+      /// <returns>A random IPv6 IPEndPoint.</returns>
+      public IPEndPoint Ipv6EndPoint()
+      {
+         return new IPEndPoint(
+            new IPAddress(Random.Bytes(16)),
+            Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort));
       }
 
       private UserAgentGenerator userAgentGenerator;

--- a/Source/Bogus/DataSets/Internet.cs
+++ b/Source/Bogus/DataSets/Internet.cs
@@ -147,12 +147,21 @@ namespace Bogus.DataSets
       }
 
       /// <summary>
-      /// Gets a random IP address.
+      /// Gets a random IP address string.
       /// </summary>
       /// <returns>A random IP address.</returns>
       public string Ip()
       {
          return $"{Random.Number(255)}.{Random.Number(255)}.{Random.Number(255)}.{Random.Number(255)}";
+      }
+
+      /// <summary>
+      /// Gets a random IPAddress type.
+      /// </summary>
+      public IPAddress IpAddress()
+      {
+         var address = new IPAddress(this.Random.Bytes(4));
+         return address;
       }
 
       /// <summary>
@@ -166,15 +175,21 @@ namespace Bogus.DataSets
             $"{bytes[0]:x}{bytes[1]:x}:{bytes[2]:x}{bytes[3]:x}:{bytes[4]:x}{bytes[5]:x}:{bytes[6]:x}{bytes[7]:x}:{bytes[8]:x}{bytes[9]:x}:{bytes[10]:x}{bytes[11]:x}:{bytes[12]:x}{bytes[13]:x}:{bytes[14]:x}{bytes[15]:x}";
       }
 
+      public IPAddress Ipv6Address()
+      {
+         var address = new IPAddress(this.Random.Bytes(16));
+         return address;
+      }
+
       /// <summary>
       /// Gets a random IPv4 IPEndPoint.
       /// </summary>
       /// <returns>A random IPv4 IPEndPoint.</returns>
       public IPEndPoint IpEndPoint()
       {
-         return new IPEndPoint(
-            new IPAddress(Random.Bytes(4)),
-            Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort));
+         var address = this.IpAddress();
+         var port = this.Random.Int( IPEndPoint.MinPort + 1, IPEndPoint.MaxPort);
+         return new IPEndPoint(address, port);
       }
 
       /// <summary>
@@ -183,9 +198,9 @@ namespace Bogus.DataSets
       /// <returns>A random IPv6 IPEndPoint.</returns>
       public IPEndPoint Ipv6EndPoint()
       {
-         return new IPEndPoint(
-            new IPAddress(Random.Bytes(16)),
-            Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort));
+         var address = this.Ipv6Address();
+         var port = this.Random.Int(IPEndPoint.MinPort + 1, IPEndPoint.MaxPort);
+         return new IPEndPoint(address,port);
       }
 
       private UserAgentGenerator userAgentGenerator;


### PR DESCRIPTION
Hello.

I'm writing a networking library for C# and needed to test with random IPEndPoints, so I thought it'd be helpful to do a PR to add into Bogus.

Apologies for being unfamiliar with Fluent Validation, so I couldn't write the tests.

The minimum port you can have in an IPEndPoint is IPEndPoint.MinPort, which is 0. However 0 is a special case for port numbers and asks the operating system to allocate a available randomly assigned port. Therefore, I've used IPEndPoint.MinPort + 1 as the minimum value as the value of 0 would never be reasonably observed in any connection.