### PR TITLE
Fixes #260 - SSNs generated by Bogus should now pass basic validation

### DIFF
--- a/Source/Benchmark/BenchRandomSubset.cs
+++ b/Source/Benchmark/BenchRandomSubset.cs
@@ -16,7 +16,7 @@ namespace Benchmark
         [Params(2, 10, 100, 500, 1000, 1999)]
         public int Selections { get; set; }
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             r = new Randomizer();

--- a/Source/Benchmark/BenchSsn.cs
+++ b/Source/Benchmark/BenchSsn.cs
@@ -1,0 +1,55 @@
+﻿using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Exporters;
+using Bogus;
+
+namespace Benchmark
+{
+   [RPlotExporter]
+   public class BenchSsn
+   {
+      private Randomizer r;
+
+      [GlobalSetup]
+      public void Setup()
+      {
+         r = new Randomizer();
+      }
+
+      [Benchmark]
+      public void SsnAlgo1()
+      {
+         var a = r.Int(1, 898);
+         var b = r.Int(1, 99);
+         var c = r.Int(1, 9999);
+
+         var result = $"{a:000}-{b:00}-{c:0000}";
+      }
+
+      [Benchmark]
+      public void SsnAlgo2()
+      {
+         var a = r.Int(1, 898);
+         var b = r.Int(1, 99);
+         var c = r.Int(1, 9999);
+
+         var result = string.Format("{0:000}-{1:00}-{2:0000}", a, b, c);
+      }
+
+      [Benchmark]
+      public void SsnAlgo3()
+      {
+         // 898 = 0b1110000010
+
+         var x = r.Int();
+
+         var a = x & 0xFFC00000 >> 22;
+
+         var b = x & 0x003F ;
+
+         var c = (x << 10 + 7 + 10);
+
+
+      }
+   }
+}

--- a/Source/Benchmark/BenchSsn.cs
+++ b/Source/Benchmark/BenchSsn.cs
@@ -13,13 +13,15 @@ namespace Benchmark
       [GlobalSetup]
       public void Setup()
       {
-         r = new Randomizer();
+         r = new Randomizer(1337);
       }
 
       [Benchmark]
       public void SsnAlgo1()
       {
          var a = r.Int(1, 898);
+         if (a == 666) a++;
+
          var b = r.Int(1, 99);
          var c = r.Int(1, 9999);
 
@@ -30,6 +32,8 @@ namespace Benchmark
       public void SsnAlgo2()
       {
          var a = r.Int(1, 898);
+         if (a == 666) a++;
+
          var b = r.Int(1, 99);
          var c = r.Int(1, 9999);
 
@@ -39,17 +43,21 @@ namespace Benchmark
       [Benchmark]
       public void SsnAlgo3()
       {
-         // 898 = 0b1110000010
-
          var x = r.Int();
 
-         var a = x & 0xFFC00000 >> 22;
+         // right shift all bits except fir the first 10 bits = 2^10 = 1024.
+         var a = (x >> (32 - 10)) % 898;
+         if (a == 0 || a == 666) a++;
 
-         var b = x & 0x003F ;
+         // use the first 7 bits = 2^7 = 128 
+         var b = (x & 0x7F);
+         if (b == 0) b++;
 
-         var c = (x << 10 + 7 + 10);
+         // last 2^14 = 16384, for last 4 digits of SSN
+         var c = (x >> 7) & 0x3FFF;
+         if (c == 0) c++;
 
-
+         var result = $"{a:000}-{b:00}-{c:0000}";
       }
    }
 }

--- a/Source/Benchmark/BenchStringFill.cs
+++ b/Source/Benchmark/BenchStringFill.cs
@@ -15,7 +15,7 @@ namespace Benchmark
       //   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")]
       public string Pool { get; set; } = "abcdefghijklmnopqrstuvwxyz";
 
-      [Setup]
+      [GlobalSetup]
       public void Setup()
       {
          this.r = new Randomizer();

--- a/Source/Benchmark/Program.cs
+++ b/Source/Benchmark/Program.cs
@@ -6,7 +6,7 @@ namespace Benchmark
    {
       static void Main()
       {
-         BenchmarkRunner.Run<BenchGenerate>();
+         BenchmarkRunner.Run<BenchSsn>();
       }
    }
 }

--- a/Source/Bogus.Tests/GitHubIssues/Issue260.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue260.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -14,26 +15,27 @@ namespace Bogus.Tests.GitHubIssues
       }
 
       [Fact]
-      public void generate_new_ssn()
+      public void fast_algo3_test()
       {
          var r = new Randomizer();
 
          var x = r.Int();
 
-         var a = (x << 10) & 0b1111_1111_10;
+         // right shift all bits except fir the first 10 bits = 2^10 = 1024.
+         var a = (x >> (32 - 10)) % 898;
+         if( a == 0 || a == 666 ) a++;
 
-         var b = (x << 10 + 7);
+         // use the first 7 bits = 2^7 = 128 
+         var b = (x & 0x7F);
+         if( b == 0 ) b++;
 
-         var c = (x << 10 + 7 + 10);
-
-         console.Dump(Convert.ToString(x, 2));
-         console.Dump(Convert.ToString(a, 2));
-         console.Dump(Convert.ToString(b, 2));
-         console.Dump(Convert.ToString(c, 2));
+         // last 2^14 = 16384, for last 4 digits of SSN
+         var c = (x >> 7) & 0x3FFF;
+         if( c == 0 ) c++;
 
          var result = $"{a:000}-{b:00}-{c:0000}";
 
-         console.Dump(result);
+         result.Should().Be("309-89-0111");
       }
    }
 }

--- a/Source/Bogus.Tests/GitHubIssues/Issue260.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue260.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bogus.Tests.GitHubIssues
+{
+   public class Issue260 : SeededTest
+   {
+      private readonly ITestOutputHelper console;
+
+      public Issue260(ITestOutputHelper console)
+      {
+         this.console = console;
+      }
+
+      [Fact]
+      public void generate_new_ssn()
+      {
+         var r = new Randomizer();
+
+         var x = r.Int();
+
+         var a = (x << 10) & 0b1111_1111_10;
+
+         var b = (x << 10 + 7);
+
+         var c = (x << 10 + 7 + 10);
+
+         console.Dump(Convert.ToString(x, 2));
+         console.Dump(Convert.ToString(a, 2));
+         console.Dump(Convert.ToString(b, 2));
+         console.Dump(Convert.ToString(c, 2));
+
+         var result = $"{a:000}-{b:00}-{c:0000}";
+
+         console.Dump(result);
+      }
+   }
+}

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -49,7 +49,7 @@ namespace Bogus.Tests
       public void check_ssn_on_person()
       {
          var p = new Person();
-         p.Ssn().Should().Be("869-28-7971");
+         p.Ssn().Should().Be("771-62-9016");
       }
 
       [Fact]

--- a/Source/Bogus/Extensions/UnitedStates/ExtensionsForUnitedStates.cs
+++ b/Source/Bogus/Extensions/UnitedStates/ExtensionsForUnitedStates.cs
@@ -20,7 +20,17 @@ namespace Bogus.Extensions.UnitedStates
          }
 
          var randomizer = p.Random;
-         var ssn = randomizer.ReplaceNumbers("###-##-####");
+
+         //See Issue 260, SSN validity:
+         // https://secure.ssa.gov/apps10/poms.nsf/lnx/0110201035
+
+         var a = randomizer.Int(1, 898);
+         if (a == 666) a++;
+
+         var b = randomizer.Int(1, 99);
+         var c = randomizer.Int(1, 9999);
+
+         var ssn = $"{a:000}-{b:00}-{c:0000}";
 
          p.context[Key] = ssn;
 


### PR DESCRIPTION
Fixes #260  - SSNs generated by Bogus should now pass basic validation.

Benchmarked 3 Algorithms:

```csharp
[Benchmark]
public void SsnAlgo1()
{
   var a = r.Int(1, 898);
   if (a == 666) a++;

   var b = r.Int(1, 99);
   var c = r.Int(1, 9999);

   var result = $"{a:000}-{b:00}-{c:0000}";
}

[Benchmark]
public void SsnAlgo2()
{
   var a = r.Int(1, 898);
   if (a == 666) a++;

   var b = r.Int(1, 99);
   var c = r.Int(1, 9999);

   var result = string.Format("{0:000}-{1:00}-{2:0000}", a, b, c);
}

[Benchmark]
public void SsnAlgo3()
{
   var x = r.Int();

   // right shift all bits except fir the first 10 bits = 2^10 = 1024.
   var a = (x >> (32 - 10)) % 898;
   if (a == 0 || a == 666) a++;

   // use the first 7 bits = 2^7 = 128
   var b = (x & 0x7F);
   if (b == 0) b++;

   // last 2^14 = 16384, for last 4 digits of SSN
   var c = (x >> 7) & 0x3FFF;
   if (c == 0) c++;

   var result = $"{a:000}-{b:00}-{c:0000}";
}
```

Bench results shown below:

![BenchSsn-barplot](https://user-images.githubusercontent.com/478118/66728958-ddc92800-edfc-11e9-8424-87402cd63d3c.png)
![BenchSsn-boxplot](https://user-images.githubusercontent.com/478118/66728959-ddc92800-edfc-11e9-83b6-76a3ee1ab7a2.png)

   Method |     Mean |    Error |   StdDev |
--------- |---------:|---------:|---------:|
 SsnAlgo1 | 888.8 ns | 2.209 ns | 1.958 ns |
 SsnAlgo2 | 887.9 ns | 1.534 ns | 1.281 ns |
 SsnAlgo3 | 851.7 ns | 4.782 ns | 4.473 ns |

I mean it's not that big of a difference, I'd rather have something easier to maintain than something hard to maintain and difficult to understand.

If people want the faster algo, fine; create a `FastSsn()` extension off `Person` and optimize as required.

So, we're going with Algo 1.

:briefcase: :necktie: ***["Taking care of business every day... Taking care of business every way..."](https://www.youtube.com/watch?v=mmwic9kFx2c)***