### PR TITLE
Add includeFormatSymbols for cnpj & cpf in brazil extensions

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/CompanyTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/CompanyTest.cs
@@ -54,9 +54,15 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_generate_cnpj_for_brazil_without_formatting()
+      {
+         company.Cnpj(includeFormatSymbols: false).Should().Be("61860606000191");
+      }
+
+      [Fact]
       public void can_generate_numeric_cnpj_for_brazil()
       {
-         company.NumericCnpj().Should().Be((ulong)61860606000191);
+         company.CnpjNumeric().Should().Be(61860606000191);
       }
 
       [Fact]

--- a/Source/Bogus.Tests/DataSetTests/CompanyTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/CompanyTest.cs
@@ -60,12 +60,6 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
-      public void can_generate_numeric_cnpj_for_brazil()
-      {
-         company.CnpjNumeric().Should().Be(61860606000191);
-      }
-
-      [Fact]
       public void can_generate_an_EIN()
       {
          company.Ein().Should().Be("61-8606064");

--- a/Source/Bogus.Tests/DataSetTests/CompanyTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/CompanyTest.cs
@@ -54,6 +54,12 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_generate_numeric_cnpj_for_brazil()
+      {
+         company.NumericCnpj().Should().Be((ulong)61860606000191);
+      }
+
+      [Fact]
       public void can_generate_an_EIN()
       {
          company.Ein().Should().Be("61-8606064");

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -10,6 +10,7 @@ using Bogus.Extensions.UnitedStates;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using Z.ExtensionMethods.ObjectExtensions;
 
 namespace Bogus.Tests
 {
@@ -127,7 +128,7 @@ namespace Bogus.Tests
       [Fact]
       public void can_generate_numeric_cpf_for_brazil()
       {
-         var obtained = Get(10, p => p.CpfNumeric());
+         var obtained = Get(10, p => p.Cpf(includeFormatSymbols: false).ToULong());
 
          console.Dump(obtained);
 

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -101,6 +101,30 @@ namespace Bogus.Tests
       }
 
       [Fact]
+      public void can_generate_numeric_cpf_for_brazil()
+      {
+         var obtained = Get(10, p => p.NumericCpf());
+
+         console.Dump(obtained);
+
+         var expect = new[]
+            {
+               (ulong)86928797118,
+               (ulong)59526934580,
+               (ulong)79830732916,
+               (ulong)88584412301,
+               (ulong)81854283529,
+               (ulong)96398934040,
+               (ulong)00647515709,
+               (ulong)62940003513,
+               (ulong)65867663116,
+               (ulong)79247813905
+            };
+
+         obtained.Should().Equal(expect);
+      }
+
+      [Fact]
       public void can_generate_cpr_number_for_denmark()
       {
          var p = new Person();
@@ -149,7 +173,7 @@ namespace Bogus.Tests
          );
          console.WriteLine(emails.DumpString());
       }
-      
+
       [Fact]
       public void person_has_full_name()
       {
@@ -185,9 +209,9 @@ namespace Bogus.Tests
 
          Date.SystemClock = () => DateTime.Now;
       }
-      
 
-      IEnumerable<string> Get(int times, Func<Person, string> a)
+
+      IEnumerable<T> Get<T>(int times, Func<Person, T> a)
       {
          return Enumerable.Range(0, times)
             .Select(i =>

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -101,24 +101,48 @@ namespace Bogus.Tests
       }
 
       [Fact]
-      public void can_generate_numeric_cpf_for_brazil()
+      public void can_generate_cpf_for_brazil_without_formatting()
       {
-         var obtained = Get(10, p => p.NumericCpf());
+         var obtained = Get(10, p => p.Cpf(includeFormatSymbols: false));
 
          console.Dump(obtained);
 
          var expect = new[]
             {
-               (ulong)86928797118,
-               (ulong)59526934580,
-               (ulong)79830732916,
-               (ulong)88584412301,
-               (ulong)81854283529,
-               (ulong)96398934040,
-               (ulong)00647515709,
-               (ulong)62940003513,
-               (ulong)65867663116,
-               (ulong)79247813905
+               "86928797118",
+               "59526934580",
+               "79830732916",
+               "88584412301",
+               "81854283529",
+               "96398934040",
+               "00647515709",
+               "62940003513",
+               "65867663116",
+               "79247813905"
+            };
+
+         obtained.Should().Equal(expect);
+      }
+
+      [Fact]
+      public void can_generate_numeric_cpf_for_brazil()
+      {
+         var obtained = Get(10, p => p.CpfNumeric());
+
+         console.Dump(obtained);
+
+         var expect = new ulong[]
+            {
+               86928797118,
+               59526934580,
+               79830732916,
+               88584412301,
+               81854283529,
+               96398934040,
+               00647515709,
+               62940003513,
+               65867663116,
+               79247813905
             };
 
          obtained.Should().Equal(expect);

--- a/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
+++ b/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
@@ -67,14 +67,6 @@ namespace Bogus.Extensions.Brazil
       }
 
       /// <summary>
-      /// Cadastro de Pessoas Físicas sem pontuação
-      /// </summary>
-      public static ulong CpfNumeric(this Person p)
-      {
-         return ulong.Parse(p.Cpf(includeFormatSymbols: false));
-      }
-
-      /// <summary>
       /// Cadastro Nacional da Pessoa Jurídica
       /// </summary>
       /// <param name="includeFormatSymbols">Includes formatting symbols.</param>
@@ -110,14 +102,6 @@ namespace Bogus.Extensions.Brazil
          }
 
          return final;
-      }
-
-      /// <summary>
-      /// Cadastro de Pessoas Físicas sem pontuação
-      /// </summary>
-      public static ulong CnpjNumeric(this Company c)
-      {
-         return ulong.Parse(c.Cnpj(includeFormatSymbols: false));
       }
    }
 }

--- a/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
+++ b/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
@@ -14,7 +14,8 @@ namespace Bogus.Extensions.Brazil
       /// <summary>
       /// Cadastro de Pessoas Físicas
       /// </summary>
-      public static string Cpf(this Person p)
+      /// <param name="includeFormatSymbols">Includes formatting symbols.</param>
+      public static string Cpf(this Person p, bool includeFormatSymbols = true)
       {
          const string Key = nameof(ExtensionsForBrazil) + "CPF";
          if( p.context.ContainsKey(Key) )
@@ -50,7 +51,15 @@ namespace Bogus.Extensions.Brazil
 
          var all = digits.Concat(new[] {check1, check2}).ToArray();
 
-         var final = $"{all[0]}{all[1]}{all[2]}.{all[3]}{all[4]}{all[5]}.{all[6]}{all[7]}{all[8]}-{all[9]}{all[10]}";
+         string final;
+         if( includeFormatSymbols )
+         {
+            final = $"{all[0]}{all[1]}{all[2]}.{all[3]}{all[4]}{all[5]}.{all[6]}{all[7]}{all[8]}-{all[9]}{all[10]}";
+         }
+         else
+         {
+            final = $"{all[0]}{all[1]}{all[2]}{all[3]}{all[4]}{all[5]}{all[6]}{all[7]}{all[8]}{all[9]}{all[10]}";
+         }
 
          p.context[Key] = final;
 
@@ -60,11 +69,16 @@ namespace Bogus.Extensions.Brazil
       /// <summary>
       /// Cadastro de Pessoas Físicas sem pontuação
       /// </summary>
-      public static ulong NumericCpf(this Person p) => ToNumeric(p.Cpf());
+      public static ulong CpfNumeric(this Person p)
+      {
+         return ulong.Parse(p.Cpf(includeFormatSymbols: false));
+      }
+
       /// <summary>
       /// Cadastro Nacional da Pessoa Jurídica
       /// </summary>
-      public static string Cnpj(this Company c)
+      /// <param name="includeFormatSymbols">Includes formatting symbols.</param>
+      public static string Cnpj(this Company c, bool includeFormatSymbols = true)
       {
          var digits = c.Random.Digits(12);
          digits[8] = 0;
@@ -84,18 +98,26 @@ namespace Bogus.Extensions.Brazil
             secondDigit = 0;
 
          var all = digits.Concat(new[] {firstDigit, secondDigit}).ToArray();
-         var final = $"{all[0]}{all[1]}.{all[2]}{all[3]}{all[4]}.{all[5]}{all[6]}{all[7]}/{all[8]}{all[9]}{all[10]}{all[11]}-{all[12]}{all[13]}";
+
+         string final;
+         if ( includeFormatSymbols )
+         {
+            final = $"{all[0]}{all[1]}.{all[2]}{all[3]}{all[4]}.{all[5]}{all[6]}{all[7]}/{all[8]}{all[9]}{all[10]}{all[11]}-{all[12]}{all[13]}";
+         }
+         else
+         {
+            final = $"{all[0]}{all[1]}{all[2]}{all[3]}{all[4]}{all[5]}{all[6]}{all[7]}{all[8]}{all[9]}{all[10]}{all[11]}{all[12]}{all[13]}";
+         }
+
          return final;
       }
 
       /// <summary>
       /// Cadastro de Pessoas Físicas sem pontuação
       /// </summary>
-      public static ulong NumericCnpj(this Company c) => ToNumeric(c.Cnpj());
-
-      /// <summary>
-      /// Converte CPF e CNPJ para um número (remove a formatação)
-      /// </summary>
-      private static ulong ToNumeric(string doc) => ulong.Parse(string.Join(string.Empty, doc.Split(new char[] { '.', '/', '-' }, System.StringSplitOptions.RemoveEmptyEntries)));
+      public static ulong CnpjNumeric(this Company c)
+      {
+         return ulong.Parse(c.Cnpj(includeFormatSymbols: false));
+      }
    }
 }

--- a/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
+++ b/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
@@ -10,7 +10,6 @@ namespace Bogus.Extensions.Brazil
    {
       private static readonly int[] CpfWeights = {10, 9, 8, 7, 6, 5, 4, 3, 2};
       private static readonly int[] CnpjWeights = {2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5, 6};
-
       /// <summary>
       /// Cadastro de Pessoas Físicas
       /// </summary>
@@ -56,7 +55,10 @@ namespace Bogus.Extensions.Brazil
 
          return final;
       }
-
+      /// <summary>
+      /// Cadastro de Pessoas Físicas sem pontuação
+      /// </summary>
+      public static ulong NumericCpf(this Person p) => ToNumeric(p.Cpf());
       /// <summary>
       /// Cadastro Nacional da Pessoa Jurídica
       /// </summary>
@@ -83,5 +85,13 @@ namespace Bogus.Extensions.Brazil
          var final = $"{all[0]}{all[1]}.{all[2]}{all[3]}{all[4]}.{all[5]}{all[6]}{all[7]}/{all[8]}{all[9]}{all[10]}{all[11]}-{all[12]}{all[13]}";
          return final;
       }
+      /// <summary>
+      /// Cadastro de Pessoas Físicas sem pontuação
+      /// </summary>
+      public static ulong NumericCnpj(this Company c) => ToNumeric(c.Cnpj());
+      /// <summary>
+      /// Converte CPF e CNPJ para um número (remove a formatação)
+      /// </summary>
+      private static ulong ToNumeric(string doc) => ulong.Parse(string.Join(string.Empty, doc.Split(new char[] { '.', '/', '-' }, System.StringSplitOptions.RemoveEmptyEntries)));
    }
 }

--- a/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
+++ b/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
@@ -10,6 +10,7 @@ namespace Bogus.Extensions.Brazil
    {
       private static readonly int[] CpfWeights = {10, 9, 8, 7, 6, 5, 4, 3, 2};
       private static readonly int[] CnpjWeights = {2, 3, 4, 5, 6, 7, 8, 9, 2, 3, 4, 5, 6};
+
       /// <summary>
       /// Cadastro de Pessoas Físicas
       /// </summary>
@@ -55,6 +56,7 @@ namespace Bogus.Extensions.Brazil
 
          return final;
       }
+
       /// <summary>
       /// Cadastro de Pessoas Físicas sem pontuação
       /// </summary>
@@ -85,10 +87,12 @@ namespace Bogus.Extensions.Brazil
          var final = $"{all[0]}{all[1]}.{all[2]}{all[3]}{all[4]}.{all[5]}{all[6]}{all[7]}/{all[8]}{all[9]}{all[10]}{all[11]}-{all[12]}{all[13]}";
          return final;
       }
+
       /// <summary>
       /// Cadastro de Pessoas Físicas sem pontuação
       /// </summary>
       public static ulong NumericCnpj(this Company c) => ToNumeric(c.Cnpj());
+
       /// <summary>
       /// Converte CPF e CNPJ para um número (remove a formatação)
       /// </summary>


### PR DESCRIPTION
Often developers need this data (cpf and cnpj) to be numeric, unformatted, that's what this implementation does.