### PR TITLE
Enhancements to Randomizer

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/ImageTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/ImageTest.cs
@@ -98,15 +98,15 @@ namespace Bogus.Tests.DataSetTests
       {
          var img = image.LoremFlickrUrl(640, 480, "dog");
 
-         img.Should().Be("https://loremflickr.com/640/480/dog/any?lock=1296054234");
+         img.Should().Be("https://loremflickr.com/640/480/dog/any?lock=1721768941");
          
          img = image.LoremFlickrUrl(100, 100, "cat");
 
-         img.Should().Be("https://loremflickr.com/100/100/cat/any?lock=235660067");
+         img.Should().Be("https://loremflickr.com/100/100/cat/any?lock=199070641");
 
          img = image.LoremFlickrUrl(100, 100, "cat,bird");
 
-         img.Should().Be("https://loremflickr.com/100/100/cat,bird/any?lock=1749342364");
+         img.Should().Be("https://loremflickr.com/100/100/cat,bird/any?lock=1035518479");
 
          img = image.LoremFlickrUrl(100, 100, "cat,bird", lockId: -1, grascale: true);
 

--- a/Source/Bogus.Tests/GitHubIssues/Issue124.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue124.cs
@@ -129,24 +129,34 @@ namespace Bogus.Tests.GitHubIssues
             .RuleFor(x => x.Obj, f => new object().OrNull(f))
             .RuleFor(x => x.Str, f => f.Random.Word().OrNull(f));
 
-         var q = faker.Generate(3);
+         var q = faker.Generate(5);
 
          console.Dump(q);
 
          q[0].Id.Should().NotBeNull();
          q[0].Gud.Should().NotBeNull();
-         q[0].Obj.Should().NotBeNull();
-         q[0].Str.Should().NotBeNull();
+         q[0].Obj.Should().BeNull();
+         q[0].Str.Should().BeNull();
 
-         q[1].Id.Should().NotBeNull();
+         q[1].Id.Should().BeNull();
          q[1].Gud.Should().NotBeNull();
-         q[1].Obj.Should().NotBeNull();
+         q[1].Obj.Should().BeNull();
          q[1].Str.Should().BeNull();
-         
+
          q[2].Id.Should().BeNull();
-         q[2].Gud.Should().BeNull();
+         q[2].Gud.Should().NotBeNull();
          q[2].Obj.Should().NotBeNull();
-         q[2].Str.Should().NotBeNull();
+         q[2].Str.Should().BeNull();
+
+         q[3].Id.Should().NotBeNull();
+         q[3].Gud.Should().NotBeNull();
+         q[3].Obj.Should().NotBeNull();
+         q[3].Str.Should().BeNull();
+
+         q[4].Id.Should().BeNull();
+         q[4].Gud.Should().NotBeNull();
+         q[4].Obj.Should().NotBeNull();
+         q[4].Str.Should().NotBeNull();
       }
 
       public class Foo

--- a/Source/Bogus.Tests/GitHubIssues/Issue124.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue124.cs
@@ -135,28 +135,28 @@ namespace Bogus.Tests.GitHubIssues
 
          q[0].Id.Should().NotBeNull();
          q[0].Gud.Should().NotBeNull();
-         q[0].Obj.Should().BeNull();
-         q[0].Str.Should().BeNull();
+         q[0].Obj.Should().NotBeNull();
+         q[0].Str.Should().NotBeNull();
 
-         q[1].Id.Should().BeNull();
+         q[1].Id.Should().NotBeNull();
          q[1].Gud.Should().NotBeNull();
-         q[1].Obj.Should().BeNull();
+         q[1].Obj.Should().NotBeNull();
          q[1].Str.Should().BeNull();
 
          q[2].Id.Should().BeNull();
-         q[2].Gud.Should().NotBeNull();
+         q[2].Gud.Should().BeNull();
          q[2].Obj.Should().NotBeNull();
-         q[2].Str.Should().BeNull();
+         q[2].Str.Should().NotBeNull();
 
-         q[3].Id.Should().NotBeNull();
+         q[3].Id.Should().BeNull();
          q[3].Gud.Should().NotBeNull();
-         q[3].Obj.Should().NotBeNull();
-         q[3].Str.Should().BeNull();
+         q[3].Obj.Should().BeNull();
+         q[3].Str.Should().NotBeNull();
 
          q[4].Id.Should().BeNull();
          q[4].Gud.Should().NotBeNull();
          q[4].Obj.Should().NotBeNull();
-         q[4].Str.Should().NotBeNull();
+         q[4].Str.Should().BeNull();
       }
 
       public class Foo

--- a/Source/Bogus.Tests/GitHubIssues/Issue260.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue260.cs
@@ -21,7 +21,7 @@ namespace Bogus.Tests.GitHubIssues
          var x = r.Int();
 
          // the remainder of this test depends on x having a predictable value
-         x.Should().Be(425714706);
+         x.Should().Be(1077349347);
 
          // right shift all bits except fir the first 10 bits = 2^10 = 1024.
          var a = (x >> (32 - 10)) % 898;
@@ -38,7 +38,7 @@ namespace Bogus.Tests.GitHubIssues
 
          var result = $"{a:000}-{b:00}-{c:0000}";
 
-         result.Should().Be("101-18-6328");
+         result.Should().Be("256-99-1799");
       }
    }
 }

--- a/Source/Bogus.Tests/GitHubIssues/Issue260.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue260.cs
@@ -20,6 +20,9 @@ namespace Bogus.Tests.GitHubIssues
 
          var x = r.Int();
 
+         // the remainder of this test depends on x having a predictable value
+         x.Should().Be(425714706);
+
          // right shift all bits except fir the first 10 bits = 2^10 = 1024.
          var a = (x >> (32 - 10)) % 898;
          if( a == 0 || a == 666 ) a++;
@@ -30,11 +33,12 @@ namespace Bogus.Tests.GitHubIssues
 
          // last 2^14 = 16384, for last 4 digits of SSN
          var c = (x >> 7) & 0x3FFF;
+         if( c >= 10000 ) c -= 10000;
          if( c == 0 ) c++;
 
          var result = $"{a:000}-{b:00}-{c:0000}";
 
-         result.Should().Be("309-89-0111");
+         result.Should().Be("101-18-6328");
       }
    }
 }

--- a/Source/Bogus.Tests/RandomizerTest.cs
+++ b/Source/Bogus.Tests/RandomizerTest.cs
@@ -124,7 +124,7 @@ namespace Bogus.Tests
       [Fact]
       public void generate_decimal_with_min_and_max()
       {
-         r.Decimal(2.2m, 5.2m).Should().Be(4.488022563614591414017291557m);
+         r.Decimal(2.2m, 5.2m).Should().Be(3.8697355489728032005903907232m);
       }
 
       [Fact]
@@ -176,12 +176,12 @@ namespace Bogus.Tests
       [Fact]
       public void generate_int32_many()
       {
-         r.Int().Should().Be(425714706);
-         r.Int().Should().Be(1767736486);
-         r.Int().Should().Be(-1019306602);
-         r.Int().Should().Be(-1398145763);
-         r.Int().Should().Be(1857743500);
-         r.Int().Should().Be(-1033498152);
+         r.Int().Should().Be(1077349347);
+         r.Int().Should().Be(1155054345);
+         r.Int().Should().Be(-1904480771);
+         r.Int().Should().Be(2101046113);
+         r.Int().Should().Be(1223601157);
+         r.Int().Should().Be(-594397672);
       }
 
       [Fact]

--- a/Source/Bogus.Tests/RandomizerTest.cs
+++ b/Source/Bogus.Tests/RandomizerTest.cs
@@ -104,6 +104,96 @@ namespace Bogus.Tests
       }
 
       [Fact]
+      public void detects_invalid_Even_range()
+      {
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Even(min: 1, max: 0);
+            });
+
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Even(min: int.MaxValue, max: int.MinValue);
+            });
+      }
+
+      [Fact]
+      public void detects_empty_Even_range()
+      {
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Even(min: 1, max: 1);
+            });
+
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Even(min: int.MaxValue, max: int.MaxValue);
+            });
+
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Even(min: int.MinValue + 1, max: int.MinValue + 1);
+            });
+      }
+
+      [Fact]
+      public void can_handle_extreme_Even_range()
+      {
+         r.Even(min: int.MinValue, max: int.MinValue).Should().Be(int.MinValue);
+         r.Even(min: int.MaxValue & ~1, max: int.MaxValue & ~1).Should().Be(int.MaxValue & ~1);
+      }
+
+      [Fact]
+      public void detects_invalid_Odd_range()
+      {
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Odd(min: 1, max: 0);
+            });
+
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Odd(min: int.MaxValue, max: int.MinValue);
+            });
+      }
+
+      [Fact]
+      public void detects_empty_Odd_range()
+      {
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Odd(min: 0, max: 0);
+            });
+
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Odd(min: int.MaxValue - 1, max: int.MaxValue - 1);
+            });
+
+         Assert.Throws<ArgumentException>(
+            () =>
+            {
+               r.Odd(min: int.MinValue, max: int.MinValue);
+            });
+      }
+
+      [Fact]
+      public void can_handle_extreme_Odd_range()
+      {
+         r.Odd(min: int.MinValue | 1, max: int.MinValue | 1).Should().Be(int.MinValue | 1);
+         r.Odd(min: int.MaxValue, max: int.MaxValue).Should().Be(int.MaxValue);
+      }
+
+      [Fact]
       public void random_bool()
       {
          r.Bool().Should().BeFalse();

--- a/Source/Bogus.Tests/RandomizerTest.cs
+++ b/Source/Bogus.Tests/RandomizerTest.cs
@@ -91,10 +91,16 @@ namespace Bogus.Tests
       }
 
       [Fact]
-      public void exclusive_int_maxvalue_number()
+      public void can_include_int_maxvalue_number()
       {
-         var max = r.Number(int.MaxValue - 1, int.MaxValue);
-         max.Should().Be(int.MaxValue - 1);
+         var max = r.Number(int.MaxValue, int.MaxValue);
+         max.Should().Be(int.MaxValue);
+      }
+
+      [Fact]
+      public void can_handle_full_int_range()
+      {
+         r.Number(int.MinValue, int.MaxValue);
       }
 
       [Fact]
@@ -118,7 +124,7 @@ namespace Bogus.Tests
       [Fact]
       public void generate_decimal_with_min_and_max()
       {
-         r.Decimal(2.2m, 5.2m).Should().Be(4.0105668499183690m);
+         r.Decimal(2.2m, 5.2m).Should().Be(4.488022563614591414017291557m);
       }
 
       [Fact]
@@ -170,10 +176,12 @@ namespace Bogus.Tests
       [Fact]
       public void generate_int32_many()
       {
-         r.Int().Should().Be(1296054233);
-         r.Int().Should().Be(-1749342366);
-         r.Int().Should().Be(-76446690);
-         r.Int().Should().Be(108870444);
+         r.Int().Should().Be(425714706);
+         r.Int().Should().Be(1767736486);
+         r.Int().Should().Be(-1019306602);
+         r.Int().Should().Be(-1398145763);
+         r.Int().Should().Be(1857743500);
+         r.Int().Should().Be(-1033498152);
       }
 
       [Fact]

--- a/Source/Bogus.Tests/RandomizerTest.cs
+++ b/Source/Bogus.Tests/RandomizerTest.cs
@@ -106,39 +106,29 @@ namespace Bogus.Tests
       [Fact]
       public void detects_invalid_Even_range()
       {
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Even(min: 1, max: 0);
-            });
+         Action act1 = () => r.Even(min: 1, max: 0);
+         act1.ShouldThrow<ArgumentException>()
+            .Where( ex => ex.Message.StartsWith("The min/max range is invalid. The minimum value '1' is greater than the maximum value '0'."));
 
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Even(min: int.MaxValue, max: int.MinValue);
-            });
+         Action act2 = () => r.Even(min: int.MaxValue, max: int.MinValue);
+         act2.ShouldThrow<ArgumentException>()
+            .Where( ex => ex.Message.StartsWith("The min/max range is invalid. The minimum value '2147483647' is greater than the maximum value '-2147483648'."));
       }
 
       [Fact]
       public void detects_empty_Even_range()
       {
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Even(min: 1, max: 1);
-            });
+         Action act1 = () => r.Even(min: 1, max: 1);
+         act1.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The specified range does not contain any even numbers."));
 
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Even(min: int.MaxValue, max: int.MaxValue);
-            });
+         Action act2 = () => r.Even(min: int.MaxValue, max: int.MaxValue);
+         act2.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The specified range does not contain any even numbers."));
 
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Even(min: int.MinValue + 1, max: int.MinValue + 1);
-            });
+         Action act3 = () => r.Even(min: int.MinValue + 1, max: int.MinValue + 1);
+         act3.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The specified range does not contain any even numbers."));
       }
 
       [Fact]
@@ -151,39 +141,29 @@ namespace Bogus.Tests
       [Fact]
       public void detects_invalid_Odd_range()
       {
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Odd(min: 1, max: 0);
-            });
+         Action act1 = () => r.Odd(min: 1, max: 0);
+         act1.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The min/max range is invalid. The minimum value '1' is greater than the maximum value '0'."));
 
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Odd(min: int.MaxValue, max: int.MinValue);
-            });
+         Action act2 = () => r.Odd(min: int.MaxValue, max: int.MinValue);
+         act2.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The min/max range is invalid. The minimum value '2147483647' is greater than the maximum value '-2147483648'."));
       }
 
       [Fact]
       public void detects_empty_Odd_range()
       {
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Odd(min: 0, max: 0);
-            });
+         Action act1 = () => r.Odd(min: 0, max: 0);
+         act1.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The specified range does not contain any odd numbers."));
 
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Odd(min: int.MaxValue - 1, max: int.MaxValue - 1);
-            });
+         Action act2 = () => r.Odd(min: int.MaxValue - 1, max: int.MaxValue - 1);
+         act2.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The specified range does not contain any odd numbers."));
 
-         Assert.Throws<ArgumentException>(
-            () =>
-            {
-               r.Odd(min: int.MinValue, max: int.MinValue);
-            });
+         Action act3 = () => r.Odd(min: int.MinValue, max: int.MinValue);
+         act3.ShouldThrow<ArgumentException>()
+            .Where(ex => ex.Message.StartsWith("The specified range does not contain any odd numbers."));
       }
 
       [Fact]

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -94,15 +94,15 @@ namespace Bogus
             // number from a range spanning all possible values of int. The Random class only supports exclusive
             // upper bounds, period, and the upper bound must be specified as an int, so the best we can get in a
             // single call is a value in the range (int.MinValue, int.MaxValue - 1). Instead, what we do is get two
-            // samples, one in the range (int.MinValue, -1) and the other as unbiased as possible, and using the
-            // second one to decide, 50% of the time we invert all the bits in the sample, shifting its range to
-            // (0, int.MaxValue).
-            var result = localSeed.Next(int.MinValue, 0);
+            // samples, each of which has just under 31 bits of entropy, and use 16 bits from each to assemble a
+            // single 16-bit number.
+            int sample1 = localSeed.Next();
+            int sample2 = localSeed.Next();
 
-            if( (localSeed.Next() & 0x10000000) == 0 )
-               result = ~result;
+            int topHalf = (sample1 >> 8) & 0xFFFF;
+            int bottomHalf = (sample2 >> 8) & 0xFFFF;
 
-            return result;
+            return unchecked((topHalf << 16) | bottomHalf);
          }
       }
 

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -116,7 +116,7 @@ namespace Bogus
       {
          // Ensure that we have a valid range.
          if( min > max )
-            throw new ArgumentException("The specified range is invalid (min > max).", nameof(max));
+            throw new ArgumentException($"The min/max range is invalid. The minimum value '{min}' is greater than the maximum value '{max}'.", nameof(max));
          if( ((min & 1) == 1) && (max - 1 < min) )
             throw new ArgumentException("The specified range does not contain any even numbers.", nameof(max));
 
@@ -144,9 +144,9 @@ namespace Bogus
       {
          // Ensure that we have a valid range.
          if( min > max )
-            throw new ArgumentException("The specified range is invalid (min > max).", nameof(max));
+            throw new ArgumentException($"The min/max range is invalid. The minimum value '{min}' is greater than the maximum value '{max}'.", nameof(max));
          if( ((max & 1) == 0) && (min + 1 > max) )
-            throw new ArgumentException("The specified range does not contain any even numbers.", nameof(max));
+            throw new ArgumentException("The specified range does not contain any odd numbers.", nameof(max));
 
          // Special case where the math below breaks.
          if ( max == int.MinValue )

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -121,13 +121,16 @@ namespace Bogus
             throw new ArgumentException(nameof(max), "The specified range does not contain any even numbers.");
 
          // Adjust the range to ensure that we always get the same number of even values as odd values.
+         // For example,
+         //   if the input is min = 1, max = 3, the new range should be min = 2, max = 3.
+         //   if the input is min = 2, max = 3, the range should remain min = 2, max = 3.
          min = (min + 1) & ~1;
          max = max | 1;
 
          if( min > max )
             return min;
 
-         // Strip off the 1 bit of a random number.
+         // Strip off the last bit of a random number to make the number even.
          return Number(min, max) & ~1;
       }
 
@@ -150,13 +153,16 @@ namespace Bogus
             return int.MinValue | 1;
 
          // Adjust the range to ensure that we always get the same number of even values as odd values.
+         // For example,
+         //   if the input is min = 2, max = 4, the new range should be min = 2, max = 3.
+         //   if the input is min = 2, max = 3, the range should remain min = 2, max = 3.
          min = min & ~1;
          max = (max - 1) | 1;
 
          if( min > max )
             return min | 1;
 
-         // Ensure that the 1 bit is set in a random number.
+         // Ensure that the last bit is set in a random number to make the number odd.
          return Number(min, max) | 1;
       }
 

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -107,15 +107,18 @@ namespace Bogus
       }
 
       /// <summary>
-      /// Returns a random even number. If the range does not contain any even numbers, the first even number after the range is returned, or int.MinValue if min is int.MaxValue.
+      /// Returns a random even number. If the range does not contain any even numbers, an <see cref="ArgumentException" /> is thrown.
       /// </summary>
       /// <param name="min">Lower bound, inclusive</param>
       /// <param name="max">Upper bound, inclusive</param>
+      /// <exception cref="ArgumentException">Thrown if it is impossible to select an odd number satisfying the specified range.</exception>
       public int Even(int min = 0, int max = 1)
       {
-         // Special case where the math below breaks.
-         if( min == int.MaxValue )
-            return int.MinValue;
+         // Ensure that we have a valid range.
+         if( min > max )
+            throw new ArgumentException(nameof(max), "The specified range is invalid (min > max).");
+         if( ((min & 1) == 1) && (max - 1 < min) )
+            throw new ArgumentException(nameof(max), "The specified range does not contain any even numbers.");
 
          // Adjust the range to ensure that we always get the same number of even values as odd values.
          min = (min + 1) & ~1;
@@ -129,12 +132,19 @@ namespace Bogus
       }
 
       /// <summary>
-      /// Returns a random odd number. If the range does not contain any odd numbers, the first odd number after the range is returned.
+      /// Returns a random odd number. If the range does not contain any odd numbers, an <see cref="ArgumentException" /> is thrown.
       /// </summary>
       /// <param name="min">Lower bound, inclusive</param>
       /// <param name="max">Upper bound, inclusive</param>
+      /// <exception cref="ArgumentException">Thrown if it is impossible to select an odd number satisfying the specified range.</exception>
       public int Odd(int min = 0, int max = 1)
       {
+         // Ensure that we have a valid range.
+         if( min > max )
+            throw new ArgumentException(nameof(max), "The specified range is invalid (min > max).");
+         if( ((max & 1) == 0) && (min + 1 > max) )
+            throw new ArgumentException(nameof(max), "The specified range does not contain any even numbers.");
+
          // Special case where the math below breaks.
          if ( max == int.MinValue )
             return int.MinValue | 1;

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -207,14 +207,13 @@ namespace Bogus
          // should not skip any possible values at the least significant end of the
          // mantissa.
 
-         int[] bits = new int[4];
+         int lowBits = Number(int.MinValue, int.MaxValue);
+         int middleBits = Number(int.MinValue, int.MaxValue);
+         int highBits = Number(int.MinValue, int.MaxValue);
 
-         bits[0] = Number(int.MinValue, int.MaxValue);
-         bits[1] = Number(int.MinValue, int.MaxValue);
-         bits[2] = Number(int.MinValue, int.MaxValue);
-         bits[3] = 0x1C0000;
+         const int Scale = 28;
 
-         decimal result = new decimal(bits);
+         decimal result = new decimal(lowBits, middleBits, highBits, isNegative: false, Scale);
 
          // Step 2: Scale the value and adjust it to the desired range. This may decrease
          // the accuracy by adjusting the scale as necessary, but we get the best possible

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -60,8 +60,8 @@ namespace Bogus
       /// <param name="maxDigit">maximum digit, inclusive</param>
       public int[] Digits(int count, int minDigit = 0, int maxDigit = 9)
       {
-         if( maxDigit > 9 || maxDigit < 0 ) throw new ArgumentException(nameof(maxDigit), "max digit can't be lager than 9 or smaller than 0");
-         if( minDigit > 9 || minDigit < 0 ) throw new ArgumentException(nameof(minDigit), "min digit can't be lager than 9 or smaller than 0");
+         if( maxDigit > 9 || maxDigit < 0 ) throw new ArgumentException("max digit can't be lager than 9 or smaller than 0", nameof(maxDigit));
+         if( minDigit > 9 || minDigit < 0 ) throw new ArgumentException("min digit can't be lager than 9 or smaller than 0", nameof(minDigit));
 
          var digits = new int[count];
          for( var i = 0; i < count; i++ )
@@ -116,9 +116,9 @@ namespace Bogus
       {
          // Ensure that we have a valid range.
          if( min > max )
-            throw new ArgumentException(nameof(max), "The specified range is invalid (min > max).");
+            throw new ArgumentException("The specified range is invalid (min > max).", nameof(max));
          if( ((min & 1) == 1) && (max - 1 < min) )
-            throw new ArgumentException(nameof(max), "The specified range does not contain any even numbers.");
+            throw new ArgumentException("The specified range does not contain any even numbers.", nameof(max));
 
          // Adjust the range to ensure that we always get the same number of even values as odd values.
          // For example,
@@ -144,9 +144,9 @@ namespace Bogus
       {
          // Ensure that we have a valid range.
          if( min > max )
-            throw new ArgumentException(nameof(max), "The specified range is invalid (min > max).");
+            throw new ArgumentException("The specified range is invalid (min > max).", nameof(max));
          if( ((max & 1) == 0) && (min + 1 > max) )
-            throw new ArgumentException(nameof(max), "The specified range does not contain any even numbers.");
+            throw new ArgumentException("The specified range does not contain any even numbers.", nameof(max));
 
          // Special case where the math below breaks.
          if ( max == int.MinValue )


### PR DESCRIPTION
This PR proposes several enhancements to the implementation of Randomizer:

- It does away with the hard upper bound of `int.MaxValue - 1` in `Number`.
  * If the caller specifies a `max` value less than `int.MaxValue`, then it simply adds one to it to make it inclusive.
  * If the caller specifies `int.MaxValue`, then it can't add 1 to `max`, so instead it subtracts 1 from `min`, adding it back into the result.
  * If the caller also specifies `int.MinValue` for min, then it can't do that either, so it takes two samples, one of which is in the range `int.MinValue`..`-1`, and the other of which is used to decide 50% of the time to invert all the bits, producing a number the range `0`..`int.MaxValue`. (This determination is not based on the least significant bit, which I understand to be the least random from the stock `Random` class.) Thus, with even probability, it will be between 0x80000000 and 0xFFFFFFFF and 0x00000000 and 0x7FFFFFFF, which is the same as having a uniform distribution across 0x80000000 to 0x7FFFFFFF.

- It streamlines `Even` and `Odd` and updates them to ensure even distribution over the possible even or odd return values.
  * They adjust the input range so that the raw range contains the same number of even and odd numbers, always starting on an even number and ending on an odd number.
  * A sample is taken in this range, and then the least significant bit is set or cleared as needed to force the number to be odd or even. Since the sample set has the same number of even and odd values, and since we trust `Number` to be an even distribution (which it _almost_ is, it's twice as likely to pick the largest possible value than any other value because of a poorly-implemented clamp internally -- but this should be virtually unnoticeable), this should ensure that the result numbers have an equally even distribution.
  * The code specifically checks for boundary cases where the range adjustment math would break, and the behaviour for ranges that don't contain suitable values is clearly documented.

- It updates the way `decimal` values are generated. The old method, scaling a `double`, meant that many, many possible values were never possible. This is because a `double`'s mantissa is only 52 bits wide, whereas in `double` it is 96 bits wide. The lower 44 bits will effectively never contain any random data. The new generator exploits the (documented) structure of the bits in `decimal`, filling the full 96 bits of the mantissa with random data (exploiting the new `Number` which can satisfy the entire 32-bit range without excluding `int.MaxValue`), and then scaling and translating the value into the desired range in a way that avoids reducing the scale as much as possible.

- It updates the way `float` values are generated in a pretty trivial way, translating them into their desired range while they are still a `double` instead of truncating their precision first. This only really affects the least significant bit of the mantissa, as I understand it, but it is the principle of the matter. :-)

Unit tests are updated correspondingly. In particular, several tests assume specific sequences of values back from `.Int()`, and needed to have their expectations updated to match the changes this rework brings in. One test had a bug, where it would use `& 16383` to generate a 4-digit value. By chance, this generated the value `0111` before, but after these changes, a value larger than `9999` is produced. I added a line to the test to ensure these values are 4 digits long.