### PR TITLE
Added unit test for #319 and fixed issue

### DIFF
--- a/Source/Bogus.Tests/GitHubIssues/Issue319.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue319.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Bogus.Tests.GitHubIssues
+{
+   public class Issue319 : SeededTest
+   {
+      class TestDataProvider : DataAttribute
+      {
+         public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+         {
+            yield return new object[] { 0m, decimal.MaxValue };
+            yield return new object[] { decimal.MinValue, decimal.MaxValue };
+            yield return new object[] { decimal.MinValue, 0m };
+            // A range whose size exceeds decimal.MaxValue but which doesn't have decimal.MinValue or decimal.MaxValue as a bound.
+            yield return new object[] { decimal.MinValue * 0.6m, decimal.MaxValue * 0.6m };
+         }
+      }
+
+      ITestOutputHelper _output;
+
+      public Issue319(ITestOutputHelper output)
+         => _output = output;
+
+      [Theory, TestDataProvider]
+      public void decimal_with_very_large_range_succeeds(decimal min, decimal max)
+      {
+         var randomizer = new Randomizer();
+
+         for (int iteration = 0; iteration < 300; iteration++)
+         {
+            try
+            {
+               randomizer.Decimal(min, max).Should().BeInRange(min, max);
+            }
+            catch
+            {
+               _output.WriteLine("Test failed on iteration {0}", iteration);
+               throw;
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
Added a unit test for issue #319 highlighting the issues with the new `Decimal()` implementation for very large ranges.
Added code to `Randomizer.Decimal` to detect these situations and compensate for them, keeping as many digits of precision as possible.