### PR TITLE
Improving README.md docs: Without Fluent Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,9 @@ for more info.
 
 ### Without Fluent Syntax
 
-You can use **Bogus** without a fluent setup. The examples below highlight three alternative ways to use **Bogus** without a fluent syntax setup.
-1. Using the `Faker` facade.
-2. Using **DataSets** directly.
-3. Using `Faker<T>` **inheritance**.
+You can use **Bogus** without a fluent setup. The examples below highlight three alternative ways to use **Bogus** without a fluent syntax setup, and all of them produce the same `Order` result:
 
-All three alternative styles of using **Bogus** produce the same `Order` result as demonstrated below:
+1. Using the `Faker` facade.
 ```csharp
 public void Using_The_Faker_Facade()
 {
@@ -224,6 +221,10 @@ public void Using_The_Faker_Facade()
         };
     o.Dump()
 }
+```
+
+2. Using **DataSets** directly.
+```csharp
 public void Using_DataSets_Directly()
 {
     var random = new Bogus.Randomizer();
@@ -236,6 +237,10 @@ public void Using_DataSets_Directly()
         };
     o.Dump();
 }
+```
+
+3. Using `Faker<T>` **inheritance**.
+```csharp
 public void Using_FakerT_Inheritance()
 {
    public class OrderFaker : Faker<Order> {
@@ -245,10 +250,12 @@ public void Using_FakerT_Inheritance()
          RuleFor(o => o.Quantity, f => f.Random.Number(1, 10));
       }
    }
-   var orderFaker = new OrderFaker();
-   var o = orderFaker.Generate();
-   o.Dump();
 }
+
+var orderFaker = new OrderFaker();
+var o = orderFaker.Generate();
+o.Dump();
+
 /* OUTPUT:
 {
   "OrderId": 61,

--- a/README.md
+++ b/README.md
@@ -206,62 +206,68 @@ for more info.
 
 ### Without Fluent Syntax
 
-You can use **Bogus** without a fluent setup. The examples below highlight three alternative ways to use **Bogus** without a fluent syntax setup, and all of them produce the same `Order` result:
+You can use **Bogus** without a fluent setup. The examples below highlight three alternative ways to use **Bogus** without a fluent syntax setup.
 
-1. Using the `Faker` facade.
+* Using the `Faker` facade.
+* Using **DataSets** directly.
+* Using `Faker<T>` **inheritance**.
+
+#### Using the `Faker` facade:
 ```csharp
 public void Using_The_Faker_Facade()
 {
-    var faker = new Faker("en");
-    var o = new Order()
-        {
-            OrderId = faker.Random.Number(1, 100),
-            Item = faker.Lorem.Sentence(),
-            Quantity = faker.Random.Number(1, 10)
-        };
-    o.Dump()
+   var faker = new Faker("en");
+   var o = new Order()
+       {
+           OrderId = faker.Random.Number(1, 100),
+           Item = faker.Lorem.Sentence(),
+           Quantity = faker.Random.Number(1, 10)
+       };
+   o.Dump()
 }
 ```
 
-2. Using **DataSets** directly.
+#### Using **DataSets** directly:
 ```csharp
 public void Using_DataSets_Directly()
 {
-    var random = new Bogus.Randomizer();
-    var lorem = new Bogus.DataSets.Lorem("en");
-    var o = new Order()
-        {
-            OrderId = random.Number(1, 100),
-            Item = lorem.Sentence(),
-            Quantity = random.Number(1, 10)
-        };
-    o.Dump();
+   var random = new Bogus.Randomizer();
+   var lorem = new Bogus.DataSets.Lorem("en");
+   var o = new Order()
+       {
+           OrderId = random.Number(1, 100),
+           Item = lorem.Sentence(),
+           Quantity = random.Number(1, 10)
+       };
+   o.Dump();
 }
 ```
 
-3. Using `Faker<T>` **inheritance**.
+#### Using `Faker<T>` inheritance:
 ```csharp
-public void Using_FakerT_Inheritance()
-{
-   public class OrderFaker : Faker<Order> {
-      public OrderFaker() {
-         RuleFor(o => o.OrderId, f => f.Random.Number(1, 100));
-         RuleFor(o => o.Item, f => f.Lorem.Sentence());
-         RuleFor(o => o.Quantity, f => f.Random.Number(1, 10));
-      }
+public class OrderFaker : Faker<Order> {
+   public OrderFaker() {
+      RuleFor(o => o.OrderId, f => f.Random.Number(1, 100));
+      RuleFor(o => o.Item, f => f.Lorem.Sentence());
+      RuleFor(o => o.Quantity, f => f.Random.Number(1, 10));
    }
 }
 
-var orderFaker = new OrderFaker();
-var o = orderFaker.Generate();
-o.Dump();
+public void Using_FakerT_Inheritance()
+{
+   var orderFaker = new OrderFaker();
+   var o = orderFaker.Generate();
+   o.Dump();
+}
+```
 
-/* OUTPUT:
+In the examples above, all three alternative styles of using **Bogus** produce the same `Order` result:
+```
 {
   "OrderId": 61,
   "Item": "vel est ipsa",
   "Quantity": 7
-} */
+}
 ```
 
 ### Bogus API Support


### PR DESCRIPTION
I split the example code into 3 blocks, so it's easier to read.