### PR TITLE
UseConstructor(), SkipConstructor() and fixing StrictMode() error

### DIFF
--- a/Source/Bogus.Tests/FakerTests.cs
+++ b/Source/Bogus.Tests/FakerTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Bogus.DataSets;
+using Bogus.Extensions;
+using Bogus.Tests.Models;
+using FluentAssertions;
+using Xunit;
+
+
+namespace Bogus.Tests
+{
+   public class FakerTests
+   {
+      [Fact]
+      public void SkipConstructor_Default_StrictMode_Satisfied()
+      {
+         _ = new Faker<NoParameterlessCtorClass>()
+            .SkipConstructor()
+            .RuleFor(x => x.Obj, x => null)
+            .RuleFor(x => x.Obj2, x => null)
+            .RuleFor(x => x.Obj3, x => null)
+            .Generate(1);
+      }
+
+      [Fact]
+      public void SkipConstructor_WithRule_Default_StrictMode_Not_Satisfied()
+      {
+         Assert.Throws<ValidationException>(() =>
+         {
+            _ = new Faker<NoParameterlessCtorClass>()
+               .SkipConstructor()
+               .RuleFor(x => x.Obj, x => null)
+               .Generate(1);
+         });
+      }
+
+      [Fact]
+      public void SkipConstructor_WithoutRules_Default_StrictMode_Not_Satisfied()
+      {
+         Assert.Throws<ValidationException>(() =>
+         {
+            _ = new Faker<NoParameterlessCtorClass>()
+               .SkipConstructor()
+               .Generate(1);
+         });
+      }
+
+      [Fact]
+      public void Not_Skipping_Constructor_Without_Parameterless_Ctor()
+      {
+         Assert.Throws<NoParameterlessCtorException<NoParameterlessCtorClass>>(() =>
+         {
+            _ = new Faker<NoParameterlessCtorClass>()
+             .Generate(1);
+         });
+      }
+
+      [Fact]
+      public void Skipping_Constructor_Overiding_StrictMode()
+      {
+
+         var faker = new Faker<NoParameterlessCtorClass>()
+          .SkipConstructor()
+          .StrictMode(false);
+
+         Assert.Contains(faker.StrictModes, (x => x.Value == false));
+         _ = faker.Generate(1);
+
+
+
+         Assert.Throws<ValidationException>(() =>
+         {
+            faker = new Faker<NoParameterlessCtorClass>()
+               .SkipConstructor()
+                .StrictMode(true);
+
+            Assert.Contains(faker.StrictModes, (x => x.Value == true));
+            _ = faker.Generate(1);
+
+         });
+
+      }
+
+
+      [Fact]
+      public void UseConstructor()
+      {
+         var faker = new Faker<NoParameterlessCtorClass>()
+            .UseConstructor(x => new NoParameterlessCtorClass(new Order(), 5));
+         faker.Generate(1);
+
+         var faker2 = new Faker<Order>()
+             .UseConstructor(x => new Order() { OrderId = 68 });
+         var order = faker2.Generate(1)[0];
+
+         Assert.Equal(68, order.OrderId);
+      }
+
+
+      [Fact]
+      public void UseConstructor_WithRule_Default_StrictMode_Not_Satisfied()
+      {
+         Assert.Throws<ValidationException>(() =>
+         {
+            _ = new Faker<NoParameterlessCtorClass>()
+               .UseConstructor(x => new NoParameterlessCtorClass(default, default))
+               .StrictMode(true)
+               .RuleFor(x => x.Obj, x => null)
+               .Generate(1);
+         });
+      }
+
+      [Fact]
+      public void UseConstructor_WithoutRules_Default_StrictMode_Not_Satisfied()
+      {
+         Assert.Throws<ValidationException>(() =>
+         {
+            _ = new Faker<NoParameterlessCtorClass>()
+                  .StrictMode(true)
+                  .UseConstructor(x => new NoParameterlessCtorClass(default, default))
+                  .Generate(1);
+         });
+      }
+
+
+      [Fact]
+      public void UseContructor_After_SkipConstructor()
+      {
+         var faker = new Faker<NoParameterlessCtorClass>()
+              .StrictMode(false)
+               .UseConstructor(x => throw new Exception("Use Constructor was not overriden"))
+               .SkipConstructor();
+         _ = faker.Generate(1);
+
+         var faker2 = new Faker<Order>()
+              .StrictMode(false)
+             .UseConstructor(x => throw new Exception("Use Constructor was not overriden"))
+             .SkipConstructor();
+
+         _ = faker2.Generate(1);
+
+      }
+
+      [Fact]
+      public void SkipConstructor_After_UseContructor()
+      {
+
+         var faker = new Faker<NoParameterlessCtorClass>()
+         .StrictMode(false)
+         .SkipConstructor()
+         .UseConstructor(x => new NoParameterlessCtorClass(new Order(), 5));
+         var instance = faker.Generate(1)[0];
+         Assert.Equal(5, instance.Obj2);
+
+         var faker2 = new Faker<Order>()
+             .StrictMode(false)
+             .SkipConstructor()
+             .UseConstructor(x => new Order() { OrderId = 68 });
+         var order = faker2.Generate(1)[0];
+         Assert.Equal(68, order.OrderId);
+
+      }
+
+
+      [Fact]
+      public void UseParameterlessConstructor_Hidden_Ctor()
+      {
+         Assert.Throws<NoParameterlessCtorException<NoParameterlessCtorClass>>(() =>
+         {
+            var faker = new Faker<NoParameterlessCtorClass>()
+            .UseConstructor(true);
+            _ = faker.Generate(1);
+         });
+
+         Assert.Throws<NoParameterlessCtorException<Order>>(() =>
+         {
+            var faker2 = new Faker<Order>()
+             .UseConstructor(true);
+            _ = faker2.Generate(1);
+         });
+
+         var faker2 = new Faker<HiddenParameterlessCtorClass>()
+           .UseConstructor(true);
+         _ = faker2.Generate(1);
+      }
+
+      [Fact]
+      public void UseParameterlessConstructor_Public_Ctor()
+      {
+         Assert.Throws<NoParameterlessCtorException<NoParameterlessCtorClass>>(() =>
+         {
+            var faker = new Faker<NoParameterlessCtorClass>()
+            .UseConstructor(false);
+            _ = faker.Generate(1);
+         });
+
+         var faker2 = new Faker<Order>()
+             .UseConstructor(false);
+         _ = faker2.Generate(1);
+
+         Assert.Throws<NoParameterlessCtorException<HiddenParameterlessCtorClass>>(() =>
+         {
+            var faker3 = new Faker<HiddenParameterlessCtorClass>()
+           .UseConstructor(false);
+         _ = faker3.Generate(1);
+         });
+      }
+
+      [Fact]
+      public void GenerateDefaultConstructor()
+      {
+
+         Assert.Throws<NoParameterlessCtorException<NoParameterlessCtorClass>>(() =>
+         {
+            var faker = new Faker<NoParameterlessCtorClass>();
+            _ = faker.Generate(1);
+         });
+
+         var faker2 = new Faker<Order>();
+         _ = faker2.Generate(1);
+
+         Assert.Throws<NoParameterlessCtorException<HiddenParameterlessCtorClass>>(() =>
+         {
+
+            var faker3 = new Faker<HiddenParameterlessCtorClass>();
+            _ = faker3.Generate(1);
+         });
+
+      }
+
+
+
+   }
+
+
+}

--- a/Source/Bogus.Tests/Models/HiddenParameterlessClass.cs
+++ b/Source/Bogus.Tests/Models/HiddenParameterlessClass.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+public class HiddenParameterlessCtorClass
+{
+
+
+   protected HiddenParameterlessCtorClass()
+   {
+     
+   }
+
+   public object Obj { get; }
+   public object Obj2 { get; set; }
+   public object Obj3;
+}

--- a/Source/Bogus.Tests/Models/NoParameterlessCtorClass.cs
+++ b/Source/Bogus.Tests/Models/NoParameterlessCtorClass.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+public class NoParameterlessCtorClass
+{
+	public NoParameterlessCtorClass(object obj, object obj2)
+	{
+      Obj = obj;
+      Obj2 = obj2;
+   }
+
+   public object Obj { get; }
+   public object Obj2 { get; set; }
+   public object Obj3;
+}

--- a/Source/Bogus.Tests/Models/ParameterlessCtorClass.cs
+++ b/Source/Bogus.Tests/Models/ParameterlessCtorClass.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+public class ParameterlessCtorClass
+{
+
+
+   public ParameterlessCtorClass()
+   {
+      
+   }
+
+   public object Obj { get; }
+   public object Obj2 { get; set; }
+   public object Obj3;
+}

--- a/Source/Bogus/NoParameterelessCtorException.cs
+++ b/Source/Bogus/NoParameterelessCtorException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Bogus
+{
+   /// <summary>
+   /// Used when 
+   /// </summary>
+   public class NoParameterlessCtorException<T> : Exception where T : class
+   {
+      public NoParameterlessCtorException(bool isHiddenConstructor,MissingMethodException innerException = null) 
+         : base($"Could not find {(isHiddenConstructor ? "hidden" : "public")} parameterless constructor in {typeof(T).Name}. Consider using {nameof(Faker<T>.SkipConstructor)}(), {nameof(Faker<T>.UseConstructor)}() or provide {(isHiddenConstructor ? "hidden" : "public")} parameterless contructor in {typeof(T).Name}", innerException)
+      {
+
+      }
+
+   }
+}


### PR DESCRIPTION
➕  Adding features for specifying constructors: `UseConstructor()` and `SkipConstructor()`
🔧  Found & Fixed bug when StrictMode(true) is used and no RuleFor() is specified

⚠️  .net standard 1.3 is missing few methods so `NotSupportedException` is thrown istead in this assembly