### PR TITLE
StrictMode(true) Fixing null reference exception

### DIFF
--- a/Source/Bogus.Tests/StrictModeTests.cs
+++ b/Source/Bogus.Tests/StrictModeTests.cs
@@ -1,5 +1,4 @@
 using System;
-using Bogus.Tests.Models;
 using FluentAssertions;
 using Xunit;
 
@@ -97,13 +96,20 @@ namespace Bogus.Tests
       }
 
       [Fact]
-      public void StrictMode_True_NoRules()
+      public void strictmode_with_no_rules_should_throw()
       {
-         Assert.Throws<ValidationException>(() => 
-         {          
-            new Faker<Order>()
-               .StrictMode(true).Generate(1);
-         });
+         var faker = new Faker<Examples.Order>()
+            .StrictMode(true);
+
+         Action act = () => faker.Generate(1);
+
+         act.Should().ThrowExactly<ValidationException>()
+            .WithMessage("*Missing Rules*")
+            .WithMessage("*Validation was called to ensure all properties*")
+            .WithMessage($"*{nameof(Examples.Order.OrderId)}*")
+            .WithMessage($"*{nameof(Examples.Order.Item)}*")
+            .WithMessage($"*{nameof(Examples.Order.Quantity)}*")
+            .WithMessage($"*{nameof(Examples.Order.LotNumber)}*");
       }
    }
 }

--- a/Source/Bogus.Tests/StrictModeTests.cs
+++ b/Source/Bogus.Tests/StrictModeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Bogus.Tests.Models;
 using FluentAssertions;
 using Xunit;
 
@@ -93,6 +94,16 @@ namespace Bogus.Tests
 
          Action act2 = () => faker2.AssertConfigurationIsValid();
          act2.Should().Throw<ValidationException>();
+      }
+
+      [Fact]
+      public void StrictMode_True_NoRules()
+      {
+         Assert.Throws<ValidationException>(() => 
+         {          
+            new Faker<Order>()
+               .StrictMode(true).Generate(1);
+         });
       }
    }
 }

--- a/Source/Bogus/Faker[T].cs
+++ b/Source/Bogus/Faker[T].cs
@@ -744,7 +744,7 @@ namespace Bogus
             {
                foreach( var propOrFieldOfT in userSet )
                {
-                  if( populateActions.TryGetValue(propOrFieldOfT, out var populateAction) )
+                  if( populateActions != null && populateActions.TryGetValue(propOrFieldOfT, out var populateAction) )
                   {
                      // Very much a .Rules() action
                      if( populateAction.ProhibitInStrictMode )

--- a/Source/Bogus/Faker[T].cs
+++ b/Source/Bogus/Faker[T].cs
@@ -744,7 +744,7 @@ namespace Bogus
             {
                foreach( var propOrFieldOfT in userSet )
                {
-                  if( populateActions != null && populateActions.TryGetValue(propOrFieldOfT, out var populateAction) )
+                  if( populateActions is not null && populateActions.TryGetValue(propOrFieldOfT, out var populateAction) )
                   {
                      // Very much a .Rules() action
                      if( populateAction.ProhibitInStrictMode )


### PR DESCRIPTION
Splitted from #338
Null reference expcetion when StrictMode(true) is used and no RuleFor() is called 