### PR TITLE
Fixes inconsistent space vs tabs on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,19 +362,19 @@ In the examples above, all three alternative styles of using **Bogus** produce t
 	* `PlaceholderUrl` - Get an image from https://placeholder.com service.
 	* `LoremFlickrUrl` - Get an image from https://loremflickr.com service.
 	* `LoremPixelUrl` - Creates an image URL with http://lorempixel.com. Note: This service is slow. Consider using PicsumUrl() as a faster alternative.
-    	* `Abstract` - Gets an abstract looking image.
-    	* `Animals` - Gets an image of an animal.
-    	* `Business` - Gets a business looking image.
-    	* `Cats` - Gets a picture of a cat.
-    	* `City` - Gets a city looking image.
-    	* `Food` - Gets an image of food.
-    	* `Nightlife` - Gets an image with city looking nightlife.
-    	* `Fashion` - Gets an image in the fashion category.
-    	* `People` - Gets an image of humans.
-    	* `Nature` - Gets an image of nature.
-    	* `Sports` - Gets an image related to sports.
-    	* `Technics` - Get a technology related image.
-    	* `Transport` - Get a transportation related image.
+	* `Abstract` - Gets an abstract looking image.
+	* `Animals` - Gets an image of an animal.
+	* `Business` - Gets a business looking image.
+	* `Cats` - Gets a picture of a cat.
+	* `City` - Gets a city looking image.
+	* `Food` - Gets an image of food.
+	* `Nightlife` - Gets an image with city looking nightlife.
+	* `Fashion` - Gets an image in the fashion category.
+	* `People` - Gets an image of humans.
+	* `Nature` - Gets an image of nature.
+	* `Sports` - Gets an image related to sports.
+	* `Technics` - Get a technology related image.
+	* `Transport` - Get a transportation related image.
 * **`Internet`**
 	* `Avatar` - Generates a legit Internet URL avatar from twitter accounts.
 	* `Email` - Generates an email address.
@@ -385,7 +385,7 @@ In the examples above, all three alternative styles of using **Bogus** produce t
 	* `DomainWord` - Generates a domain word used for domain names.
 	* `DomainSuffix` - Generates a domain name suffix like .com, .net, .org
 	* `Ip` - Gets a random IPv4 address string.
-  * `Port` - Generates a random port number.
+	* `Port` - Generates a random port number.
 	* `IpAddress` - Gets a random IPv4 IPAddress type.
 	* `IpEndPoint` - Gets a random IPv4 IPEndPoint.
 	* `Ipv6` - Generates a random IPv6 address string.

--- a/README.md
+++ b/README.md
@@ -362,19 +362,19 @@ In the examples above, all three alternative styles of using **Bogus** produce t
 	* `PlaceholderUrl` - Get an image from https://placeholder.com service.
 	* `LoremFlickrUrl` - Get an image from https://loremflickr.com service.
 	* `LoremPixelUrl` - Creates an image URL with http://lorempixel.com. Note: This service is slow. Consider using PicsumUrl() as a faster alternative.
-	* `Abstract` - Gets an abstract looking image.
-	* `Animals` - Gets an image of an animal.
-	* `Business` - Gets a business looking image.
-	* `Cats` - Gets a picture of a cat.
-	* `City` - Gets a city looking image.
-	* `Food` - Gets an image of food.
-	* `Nightlife` - Gets an image with city looking nightlife.
-	* `Fashion` - Gets an image in the fashion category.
-	* `People` - Gets an image of humans.
-	* `Nature` - Gets an image of nature.
-	* `Sports` - Gets an image related to sports.
-	* `Technics` - Get a technology related image.
-	* `Transport` - Get a transportation related image.
+    	* `Abstract` - Gets an abstract looking image.
+    	* `Animals` - Gets an image of an animal.
+    	* `Business` - Gets a business looking image.
+    	* `Cats` - Gets a picture of a cat.
+    	* `City` - Gets a city looking image.
+    	* `Food` - Gets an image of food.
+    	* `Nightlife` - Gets an image with city looking nightlife.
+    	* `Fashion` - Gets an image in the fashion category.
+    	* `People` - Gets an image of humans.
+    	* `Nature` - Gets an image of nature.
+    	* `Sports` - Gets an image related to sports.
+    	* `Technics` - Get a technology related image.
+    	* `Transport` - Get a transportation related image.
 * **`Internet`**
 	* `Avatar` - Generates a legit Internet URL avatar from twitter accounts.
 	* `Email` - Generates an email address.


### PR DESCRIPTION
This was creating additional nesting on the readme that was confusing.
It made methods appear as nested methods of siblings.