### PR TITLE
even end digit for females, odd for males

### DIFF
--- a/Source/Bogus/Extensions/Denmark/ExtensionsForDenmark.cs
+++ b/Source/Bogus/Extensions/Denmark/ExtensionsForDenmark.cs
@@ -17,7 +17,7 @@
          }
 
          var r = p.Random;
-         var final = $"{p.DateOfBirth:ddMMyy}-{r.Replace("####")}";
+         var final = $"{p.DateOfBirth:ddMMyy}-{r.Replace("###")}{(p.Gender == DataSets.Name.Gender.Female ? r.Even(0, 9) : r.Odd(0, 9))}";
 
          p.context[Key] = final;
          return final;


### PR DESCRIPTION
According to the CPR register i Denmark, all female CPR numbers should end with an even number and odd numbers for male