### PR TITLE
New Feature: Random DateOnly and TimeOnly

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Bogus.Tests.DataSetTests
 {
-   public class DateTest : SeededTest
+   public partial class DateTest : SeededTest
    {
       public DateTest()
       {

--- a/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Globalization;
+using Bogus.DataSets;
+using FluentAssertions;
+using Xunit;
+
+namespace Bogus.Tests.DataSetTests
+{
+   public partial class DateTest
+   {
+#if NET6_0
+      [Fact]
+      public void can_get_dateonly_in_past()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddYears(-1);
+
+         var somePastDate = date.PastDateOnly(refDate: now);
+         somePastDate.Should().BeInRange(maxBehind, now);
+      }
+
+      [Fact]
+      public void can_get_dateonly_in_past_with_custom_options()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddYears(-5);
+
+         var somePastDate = date.PastDateOnly(5, now);
+
+         somePastDate.Should().BeInRange(maxBehind, now);
+      }
+
+      [Fact]
+      public void get_a_dateonly_that_will_happen_soon()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxDate = now.AddDays(3);
+
+         var someDateSoon = date.SoonDateOnly(3, now);
+
+         someDateSoon.Should().BeInRange(now, maxDate);
+      }
+
+      [Fact]
+      public void can_get_dateonly_in_future()
+      {
+         var now = DateOnly.Parse("1/1/1990", CultureInfo.InvariantCulture);
+         var maxDate = now.AddYears(1);
+
+         var someFutureDate = date.FutureDateOnly(refDate: now);
+         someFutureDate.Should().BeInRange(now, maxDate);
+      }
+
+      [Fact]
+      public void can_get_dateonly_in_future_with_options()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxDate = now.AddYears(5);
+
+         var someFutureDate = date.FutureDateOnly(5, now);
+         someFutureDate.Should().BeInRange(now, maxDate);
+      }
+
+      [Fact]
+      public void can_get_random_dateonly_between_two_dates()
+      {
+         var start = DateOnly.Parse("8/8/2020", CultureInfo.InvariantCulture);
+         var end = DateOnly.Parse("12/12/2021", CultureInfo.InvariantCulture);
+
+         var someDate = date.BetweenDateOnly(start, end);
+
+         someDate.Should().BeInRange(start, end);
+
+         //and reverse...
+         var otherDate = date.BetweenDateOnly(end, start);
+         otherDate.Should().BeInRange(start, end);
+      }
+
+      [Fact]
+      public void can_get_dateonly_recently_within_the_year()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddDays(-1);
+
+         var someRecentDate = date.RecentDateOnly(refDate: now);
+
+         someRecentDate.Should().BeInRange(maxBehind, now);
+      }
+
+      [Fact]
+      public void can_get_random_timeonly_between_two_times_basic()
+      {
+         var start = TimeOnly.Parse("1:00 PM", CultureInfo.InvariantCulture);
+         var end = TimeOnly.Parse("2:00 PM", CultureInfo.InvariantCulture);
+
+         var someTimeBetween = date.BetweenTimeOnly(start, end);
+         someTimeBetween.IsBetween(start, end).Should().BeTrue();
+
+         var outside = TimeOnly.Parse("2:30 PM", CultureInfo.InvariantCulture);
+         outside.IsBetween(start, end).Should().BeFalse();
+      }
+
+      [Fact]
+      public void can_get_random_timeonly_between_two_times_wrap_around()
+      {
+         //wrap around from 2:00 PM to 1:00 PM; times from 1:00 PM -> 2:00 PM is excluded.
+         var start = TimeOnly.Parse("2:00 PM", CultureInfo.InvariantCulture);
+         var end = TimeOnly.Parse("1:00 PM", CultureInfo.InvariantCulture);
+
+         var someTimeBetween = date.BetweenTimeOnly(end, start);
+         someTimeBetween.IsBetween(end, start).Should().BeTrue();
+
+         var outside = TimeOnly.Parse("1:30 PM", CultureInfo.InvariantCulture);
+         outside.IsBetween(start, end).Should().BeFalse();
+      }
+
+      [Fact]
+      public void can_get_a_timeonly_that_will_happen_soon()
+      {
+         var now = TimeOnly.Parse("1:00 PM", CultureInfo.InvariantCulture);
+         var maxTime = now.AddMinutes(5);
+
+         var timeSoon = date.SoonTimeOnly(5, now);
+
+         timeSoon.IsBetween(now, maxTime).Should().BeTrue();
+      }
+
+      [Fact]
+      public void can_get_a_timeonly_that_happened_recently()
+      {
+         var now = TimeOnly.Parse("2:00 PM", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddMinutes(-5);
+
+         var timeRecent = date.RecentTimeOnly(5, now);
+         timeRecent.IsBetween(maxBehind, now).Should().BeTrue();
+      }
+#endif
+   }
+}

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -5,7 +5,7 @@ namespace Bogus.DataSets
    /// <summary>
    /// Methods for generating dates
    /// </summary>
-   public class Date : DataSet
+   public partial class Date : DataSet
    {
       private bool hasMonthWideContext;
       private bool hasMonthAbbrContext;

--- a/Source/Bogus/DataSets/Date.net60.cs
+++ b/Source/Bogus/DataSets/Date.net60.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Bogus.DataSets
+{
+   public partial class Date
+   {
+#if NET6_0
+      /// <summary>
+      /// Get a random <see cref="DateOnly"/> between <paramref name="start"/> and <paramref name="end"/>.
+      /// </summary>
+      /// <param name="start">Start date</param>
+      /// <param name="end">End date</param>
+      public DateOnly BetweenDateOnly(DateOnly start, DateOnly end)
+      {
+         var maxDay = Math.Max(start.DayNumber, end.DayNumber);
+         var minDay = Math.Min(start.DayNumber, end.DayNumber);
+
+         var someDayNumber = this.Random.Number(minDay, maxDay);
+
+         var dateBetween = DateOnly.FromDayNumber(someDayNumber);
+         return dateBetween;
+      }
+
+      /// <summary>
+      /// Get a <see cref="DateOnly"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
+      /// </summary>
+      /// <param name="yearsToGoBack">Years to go back from <paramref name="refDate"/>. Default is 1 year.</param>
+      /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
+      public DateOnly PastDateOnly(int yearsToGoBack = 1, DateOnly? refDate = null)
+      {
+         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var maxBehind = start.AddYears(-yearsToGoBack);
+
+         return BetweenDateOnly(maxBehind, start);
+      }
+
+      /// <summary>
+      /// Get a <see cref="DateOnly"/> that will happen soon.
+      /// </summary>
+      /// <param name="days">A date no more than <paramref name="days"/> ahead.</param>
+      /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
+      public DateOnly SoonDateOnly(int days = 1, DateOnly? refDate = null)
+      {
+         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var maxForward = start.AddDays(days);
+
+         return BetweenDateOnly(start, maxForward);
+      }
+
+      /// <summary>
+      /// Get a <see cref="DateOnly"/> in the future between <paramref name="refDate"/> and <paramref name="yearsToGoForward"/>.
+      /// </summary>
+      /// <param name="yearsToGoForward">Years to go forward from <paramref name="refDate"/>. Default is 1 year.</param>
+      /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
+      public DateOnly FutureDateOnly(int yearsToGoForward = 1, DateOnly? refDate = null)
+      {
+         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var maxForward = start.AddYears(yearsToGoForward);
+
+         return BetweenDateOnly(start, maxForward);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="DateOnly"/> within the last few days.
+      /// </summary>
+      /// <param name="days">Number of days to go back.</param>
+      /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
+      public DateOnly RecentDateOnly(int days = 1, DateOnly? refDate = null)
+      {
+         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var maxBehind = start.AddDays(-days);
+
+         return BetweenDateOnly(maxBehind, start);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="TimeOnly"/> between <paramref name="start"/> and <paramref name="end"/>.
+      /// </summary>
+      /// <param name="start">Start time</param>
+      /// <param name="end">End time</param>
+      public TimeOnly BetweenTimeOnly(TimeOnly start, TimeOnly end)
+      {
+         var diff = end - start;
+         var diffTicks = diff.Ticks;
+
+         var part = RandomTimeSpanFromTicks(diffTicks);
+
+         return start.Add(part);
+      }
+
+      /// <summary>
+      /// Get a <see cref="TimeOnly"/> that will happen soon.
+      /// </summary>
+      /// <param name="mins">Minutes no more than <paramref name="mins"/> ahead.</param>
+      /// <param name="refTime">The time to start calculations. Default is time from <see cref="DateTime.Now"/>.</param>
+      public TimeOnly SoonTimeOnly(int mins = 60, TimeOnly? refTime = null)
+      {
+         var start = refTime ?? TimeOnly.FromDateTime(SystemClock());
+         var maxForward = start.AddMinutes(mins);
+
+         return BetweenTimeOnly(start, maxForward);
+      }
+
+      /// <summary>
+      /// Get a random <see cref="TimeOnly"/> within the last few Minutes.
+      /// </summary>
+      /// <param name="mins">Minutes <paramref name="mins"/> of the day to go back.</param>
+      /// <param name="refTime">The Time to start calculations. Default is time from <see cref="DateTime.Now"/>.</param>
+      public TimeOnly RecentTimeOnly(int mins = 60, TimeOnly? refTime = null)
+      {
+         var start = refTime ?? TimeOnly.FromDateTime(SystemClock());
+         var maxBehind = start.AddMinutes(-mins);
+
+         return BetweenTimeOnly(maxBehind, start);
+      }
+#endif
+   }
+}


### PR DESCRIPTION
- Added Support to below methods for DateOnly and TimeOnly

      - `PastDateOnly` - Make defaults consistent with Past() DateTime
      - `SoonDateOnly` - Make defaults consistent with Soon() DateTime
      - `FutureDateOnly` - Make defaults consistent with Future() DateTime
      - `BetweenDateOnly` - Make defaults consistent with Between() DateTime
      - `RecentDateOnly` - Make defaults consistent with Recent() DateTime
      - `RecentTimeOnly` - Some time in the last 15 minutes
      - `SoonTimeOnly` - Some time in the next 15 minutes
      - `BetweenTimeOnly` - Some TimeOnly Between Start and End; always in a clockwise direction

- Added unit tests for each functionality
- Fixed ramifications of introduction of .NET 6 & C#10, those are
      - Fixed ambiguity between `DistinctBy()` from MoreLinq and System.Linq. `DictinctBy()` is newly introduced to Linq in C#10
      - Added `if !NET6_0` to not run one locale unit test for .NET 6, it is failing in .NET 6