### PR TITLE
Added extension Samordningsnummer with unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ In the examples above, all three alternative styles of using **Bogus** produce t
 	* `Bogus.Person.Cnp()` - Romanian Personal Identification number (CNP)
 * **`using Bogus.Extensions.Sweden;`**
 	* `Bogus.Person.Personnummer()` - Swedish national identity number
+	* `Bogus.Person.Samordningsnummer()` - Swedish coordination number
 * **`using Bogus.Extensions.UnitedKingdom;`**
 	* `Bogus.DataSets.Vehicle.GbRegistrationPlate()` - GB Vehicle Registration Plate
 	* `Bogus.DataSets.Finance.SortCode()` - Banking Sort Code


### PR DESCRIPTION
Government agencies, insurance companies and a few others have a vested interest in registering individuals that do not have a Swedish national  identity number. In these cases they can be given a collaboration number which basically follows the same format and rules with one notable exception; The "day" is offset by 60. This addition allows users to fake samordningsnummer.