### PR TITLE
Fix docstring that used `example` tag instead of `exception`

### DIFF
--- a/Source/Benchmark/BenchRandomSubset.cs
+++ b/Source/Benchmark/BenchRandomSubset.cs
@@ -39,7 +39,7 @@ namespace Benchmark
         /// Helper to pick random subset of elements out of the list.
         /// </summary>
         /// <param name="amountToPick">amount of elements to pick of the list.</param>
-        /// <example cref="ArgumentException">if amountToPick is lower than zero.</example>
+        /// <exception cref="ArgumentException">if amountToPick is lower than zero.</example>
         public IEnumerable<T> PickRandom<T>(IEnumerable<T> items, int amountToPick)
         {
             if (amountToPick < 0)

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -251,7 +251,7 @@ namespace Bogus
       /// Helper to pick random subset of elements out of the list.
       /// </summary>
       /// <param name="amountToPick">amount of elements to pick of the list.</param>
-      /// <example cref="ArgumentException">if amountToPick is lower than zero.</example>
+      /// <exception cref="ArgumentException">if amountToPick is lower than zero.</exception>
       public IEnumerable<T> PickRandom<T>(IEnumerable<T> items, int amountToPick)
       {
          if( amountToPick < 0 )


### PR DESCRIPTION
Probable typo. 

This makes sure that hovering over the method in IDE's has the relevant display for these exceptions. With the example tag, not even the name of the exception that was going to throw was visible.