### PR TITLE
Add option to generate strict VIN (exclusive characters I, O and Q)

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/VehicleTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/VehicleTest.cs
@@ -27,6 +27,12 @@ public class VehicleTest : SeededTest
    }
 
    [Fact]
+   public void can_get_a_strict_vin_number()
+   {
+      vehicle.Vin(true).Should().Be("K3TM1L1NF9Y575714");
+   }
+
+   [Fact]
    public void can_get_a_manufacture()
    {
       vehicle.Manufacturer().Should().Be("Maserati");

--- a/Source/Bogus/DataSets/Vehicle.cs
+++ b/Source/Bogus/DataSets/Vehicle.cs
@@ -7,16 +7,28 @@ namespace Bogus.DataSets;
 /// </summary>
 public class Vehicle : DataSet
 {
+   private const string StrictUpperCase = "ABCDEFGHJKLMNPRSTUVWXYZ";
+   private const string StrictAlphaNumericUpperCase = Chars.Numbers + StrictUpperCase;
+
    /// <summary>
    /// Generate a vehicle identification number (VIN).
    /// </summary>
-   public string Vin()
+   /// <param name="strict">Limits the acceptable characters to alpha numeric uppercase except I, O and Q.</param>
+   public string Vin(bool strict = false)
    {
       var sb = new StringBuilder();
 
-      sb.Append(this.Random.String2(10, Chars.AlphaNumericUpperCase));
-      sb.Append(this.Random.String2(1, Chars.UpperCase));
-      sb.Append(this.Random.String2(1, Chars.AlphaNumericUpperCase));
+      var allowedUpperCase = Chars.UpperCase;
+      var allowedAlphaNumericChars = Chars.AlphaNumericUpperCase;
+      if (strict)
+      {
+         allowedUpperCase = StrictUpperCase;
+         allowedAlphaNumericChars = StrictAlphaNumericUpperCase;
+      }
+
+      sb.Append(this.Random.String2(10, allowedAlphaNumericChars));
+      sb.Append(this.Random.String2(1, allowedUpperCase));
+      sb.Append(this.Random.String2(1, allowedAlphaNumericChars));
       sb.Append(this.Random.Number(min: 10000, max: 99999));
 
       return sb.ToString();


### PR DESCRIPTION
Adds an optional boolean to opt-in to generating a VIN using a more strict characterset.

> In 1981, the [National Highway Traffic Safety Administration](https://en.wikipedia.org/wiki/National_Highway_Traffic_Safety_Administration) of the United States standardized the format.[[1]](https://en.wikipedia.org/wiki/Vehicle_identification_number#cite_note-nhtsa1-1) It required all on-road vehicles sold to contain a 17-character VIN, which does not include the letters O (o), I (i), and Q (q) (to avoid confusion with numerals 0, 1, and 9).

Fixes #449