### PR TITLE
Fix incorrect generation for Finnish social security number

### DIFF
--- a/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
+++ b/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
@@ -34,7 +34,7 @@ public static class ExtensionsForFinland
       // gives the remainder as 30, and since A=10, B=11, etc. ending up with Y=30.
       // Note that letters G, I, O, and Q are skipped.
 
-      var controlCharTable = "0123456789ABCDEFHJKLMNPRSTUVWXY";
+      const string controlCharTable = "0123456789ABCDEFHJKLMNPRSTUVWXY";
       var r = p.Random;
 
       var year = p.DateOfBirth.Year;

--- a/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
+++ b/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
@@ -1,4 +1,6 @@
-﻿namespace Bogus.Extensions.Finland;
+﻿using Bogus.DataSets;
+
+namespace Bogus.Extensions.Finland;
 
 /// <summary>
 /// API extensions specific for a geographical location.
@@ -23,13 +25,16 @@ public static class ExtensionsForFinland
       // YY - DOB
       // C - Century
       // ZZZ odd for males, even for females
+      // Numbers 900-999 are only for temporary use, ie. in hospitals.
       // Q = The control character is calculated as the remainder of DDMMYYZZZ
       // divided by 31, i.e. drop the century sign and divide the resulting nine
       // digit number by 31. For remainders below ten, the remainder itself is
       // the control character, otherwise pick the corresponding character from
       // string "0123456789ABCDEFHJKLMNPRSTUVWXY". For example, 311280888 divided by 31
       // gives the remainder as 30, and since A=10, B=11, etc. ending up with Y=30.
+      // Note that letters G, I, O, and Q are skipped.
 
+      var controlCharTable = "0123456789ABCDEFHJKLMNPRSTUVWXY";
       var r = p.Random;
 
       var year = p.DateOfBirth.Year;
@@ -40,16 +45,17 @@ public static class ExtensionsForFinland
       else if( year >= 1900 && year <= 1999 )
          c = "-";
 
+      var z = r.Int(2, 449) * 2;
+      if( p.Gender == Name.Gender.Male )
+         z++;
+
+      var zzz = z.ToString("D3");
+
       var ddMMyy = $"{p.DateOfBirth:ddMMyy}";
 
-      var n = int.Parse(ddMMyy) % 31;
+      var n = int.Parse($"{ddMMyy}{zzz}") % 31;
 
-      var q = n.ToString();
-      if( n >= 10 )
-         q = ((char)('A' + (n - 10))).ToString();
-
-      //no idea if its female or male.
-      var zzz = r.Replace("###");
+      var q = controlCharTable[n].ToString();
 
       var final = $"{ddMMyy}{c}{zzz}{q}";
 


### PR DESCRIPTION
There were three issues with calculating control character for Finnish personal identity code (henkilötunnus).
1. Three-digit part after birthdate was not taken into account when calculating it.
2. Invalid characters were not skipped.
3. Gender was ignored.

It was also (rarely) possible to get 000 or 001 as the number part, both of which invalid.

This also changes that the number part is always between 002-899. Numbers 900-999 do not exist "in the wild", they are strictly reserved for temporary identity codes.
There could of course be an option to also allow temporary codes, or generate only them. I can add them if you wish.

How the identity code is formed: https://dvv.fi/en/personal-identity-code

Fixes #392
