### PR TITLE
Fixes VIN sometimes has 18 character length

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/VehicleTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/VehicleTest.cs
@@ -20,6 +20,13 @@ public class VehicleTest : SeededTest
    }
 
    [Fact]
+   public void cannot_return_vin_bigger_than_17_chars()
+   {
+      vehicle.Random = new Randomizer(43576);
+      vehicle.Vin().Should().HaveLength(17).And.Be("XTVJ5JFU2YBV99999");
+   }
+
+   [Fact]
    public void can_get_a_manufacture()
    {
       vehicle.Manufacturer().Should().Be("Maserati");

--- a/Source/Bogus/DataSets/Vehicle.cs
+++ b/Source/Bogus/DataSets/Vehicle.cs
@@ -17,7 +17,7 @@ public class Vehicle : DataSet
       sb.Append(this.Random.String2(10, Chars.AlphaNumericUpperCase));
       sb.Append(this.Random.String2(1, Chars.UpperCase));
       sb.Append(this.Random.String2(1, Chars.AlphaNumericUpperCase));
-      sb.Append(this.Random.Number(min: 10000, max: 100000));
+      sb.Append(this.Random.Number(min: 10000, max: 99999));
 
       return sb.ToString();
    }
@@ -52,5 +52,5 @@ public class Vehicle : DataSet
    public string Fuel()
    {
       return GetRandomArrayItem("fuel");
-   } 
+   }
 }


### PR DESCRIPTION
The last appended random number segment of a VIN could sometimes yield an invalid VIN because the max allowed number value was 100000. This caused the returned VIN to have a length of 18 characters.

Without the fix, the new test case in this PR would produce an assertion exception:
```
Expected string with length 17, but found string "XTVJ5JFU2YBV100000" with length 18.
```