### PR TITLE
Reference date

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -351,7 +351,7 @@ namespace Bogus.Tests.DataSetTests
       public void use_dataset_reference_date_if_set()
       {
          var referenceDate = new DateTime(2009, 12, 30, 12, 30, 0);
-         var d = new Date(referenceDate);
+         var d = new Date(referenceDate: () => referenceDate);
 
          d.Recent(0).Should()
             .BeOnOrBefore(referenceDate)
@@ -365,7 +365,7 @@ namespace Bogus.Tests.DataSetTests
          var referenceDate = new DateTime(2009, 12, 30, 12, 30, 0);
          var now = DateTime.Now;
 
-         var d = new Date(referenceDate);
+         var d = new Date(referenceDate: () => referenceDate);
 
          d.Recent(0, now).Should()
             .BeOnOrBefore(now)

--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -348,6 +348,32 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void use_dataset_reference_date_if_set()
+      {
+         var referenceDate = new DateTime(2009, 12, 30, 12, 30, 0);
+         var d = new Date(referenceDate);
+
+         d.Recent(0).Should()
+            .BeOnOrBefore(referenceDate)
+            .And
+            .BeOnOrAfter(referenceDate.Date);
+      }
+
+      [Fact]
+      public void ignore_dataset_reference_date()
+      {
+         var referenceDate = new DateTime(2009, 12, 30, 12, 30, 0);
+         var now = DateTime.Now;
+
+         var d = new Date(referenceDate);
+
+         d.Recent(0, now).Should()
+            .BeOnOrBefore(now)
+            .And
+            .BeOnOrAfter(now.Date);
+      }
+
+      [Fact]
       public void can_get_timezone_string()
       {
          date.TimeZoneString().Should().Be("Asia/Yerevan");

--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -351,7 +351,7 @@ namespace Bogus.Tests.DataSetTests
       public void use_dataset_reference_date_if_set()
       {
          var referenceDate = new DateTime(2009, 12, 30, 12, 30, 0);
-         var d = new Date(referenceDate: () => referenceDate);
+         var d = new Date(() => referenceDate);
 
          d.Recent(0).Should()
             .BeOnOrBefore(referenceDate)
@@ -365,7 +365,7 @@ namespace Bogus.Tests.DataSetTests
          var referenceDate = new DateTime(2009, 12, 30, 12, 30, 0);
          var now = DateTime.Now;
 
-         var d = new Date(referenceDate: () => referenceDate);
+         var d = new Date(() => referenceDate);
 
          d.Recent(0, now).Should()
             .BeOnOrBefore(now)

--- a/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
@@ -62,6 +62,16 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_dateonly_changed_reference_date()
+      {
+         var referenceDate = DateTime.Parse("1/1/1990", CultureInfo.InvariantCulture);
+         var d = new Date(() => referenceDate);
+
+         var recentDateOnly = d.RecentDateOnly(0);
+         recentDateOnly.Should().Be(DateOnly.FromDateTime(referenceDate.Date));
+      }
+
+      [Fact]
       public void can_get_random_dateonly_between_two_dates()
       {
          var start = DateOnly.Parse("8/8/2020", CultureInfo.InvariantCulture);
@@ -133,6 +143,16 @@ namespace Bogus.Tests.DataSetTests
 
          var timeRecent = date.RecentTimeOnly(5, now);
          timeRecent.IsBetween(maxBehind, now).Should().BeTrue();
+      }
+
+      [Fact]
+      public void can_get_timeonly_changed_reference_date()
+      {
+         var referenceDate = new DateTime(1990, 1, 1, 12, 30, 06);
+         var d = new Date(() => referenceDate);
+
+         var recentTimeOnly = d.RecentTimeOnly(0);
+         recentTimeOnly.Should().Be(TimeOnly.FromDateTime(referenceDate));
       }
 #endif
    }

--- a/Source/Bogus.Tests/LocaleTests/PtLocale.cs
+++ b/Source/Bogus.Tests/LocaleTests/PtLocale.cs
@@ -38,7 +38,7 @@ namespace Bogus.Tests.LocaleTests
       [Fact]
       public void date_tests()
       {
-         var d = new Date("pt_PT");
+         var d = new Date(locale: "pt_PT");
 
          d.Month().Should().Be("Agosto");
          d.Month(abbreviation: true).Should().Be("Fev");

--- a/Source/Bogus.Tests/LocaleTests/PtLocale.cs
+++ b/Source/Bogus.Tests/LocaleTests/PtLocale.cs
@@ -38,7 +38,7 @@ namespace Bogus.Tests.LocaleTests
       [Fact]
       public void date_tests()
       {
-         var d = new Date(locale: "pt_PT");
+         var d = new Date("pt_PT");
 
          d.Month().Should().Be("Agosto");
          d.Month(abbreviation: true).Should().Be("Fev");

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -235,6 +235,18 @@ namespace Bogus.Tests
          Date.SystemClock = () => DateTime.Now;
       }
 
+      [Fact]
+      public void generate_birthday_with_relative_date()
+      {
+         var referenceDate = new DateTime(2019, 3, 21, 1, 1, 1);
+         var p1 = new Person(referenceDate: referenceDate, seed: 1337);
+         var p2 = new Person(seed: 1337);
+
+         var diff = (int)(p2.DateOfBirth - p1.DateOfBirth).TotalSeconds;
+         var expected = (int)(Date.SystemClock() - referenceDate).TotalSeconds;
+         diff.Should().Be(expected);
+      }
+
 
       IEnumerable<T> Get<T>(int times, Func<Person, T> a)
       {

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -27,7 +27,14 @@ namespace Bogus.DataSets
       /// <summary>
       /// Create a Date dataset
       /// </summary>
-      public Date(string locale = "en", Func<DateTime?> referenceDate = null) : base(locale)
+      public Date(string locale = "en") : this(null, locale)
+      {
+      }
+
+      /// <summary>
+      /// Create a Date dataset with reference date set
+      /// </summary>
+      public Date(Func<DateTime?> referenceDate, string locale = "en") : base(locale)
       {
          _referenceDate = referenceDate;
 

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -7,7 +7,7 @@ namespace Bogus.DataSets
    /// </summary>
    public partial class Date : DataSet
    {
-      private readonly DateTime? _referenceDate;
+      private readonly Func<DateTime?> _referenceDate;
 
       private bool hasMonthWideContext;
       private bool hasMonthAbbrContext;
@@ -27,7 +27,7 @@ namespace Bogus.DataSets
       /// <summary>
       /// Create a Date dataset
       /// </summary>
-      public Date(DateTime? referenceDate = null, string locale = "en") : base(locale)
+      public Date(string locale = "en", Func<DateTime?> referenceDate = null) : base(locale)
       {
          _referenceDate = referenceDate;
 
@@ -37,7 +37,7 @@ namespace Bogus.DataSets
          this.hasWeekdayAbbrContext = HasKey("weekday.abbr_context", false);
       }
 
-      private DateTime GetDefaultDate() => GetDefaultDate();
+      private DateTime GetDate() => _referenceDate?.Invoke() ?? SystemClock();
 
       /// <summary>
       /// Get a <see cref="DateTime"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
@@ -46,7 +46,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Past(int yearsToGoBack = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? GetDefaultDate();
+         var maxDate = refDate ?? GetDate();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -64,7 +64,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset PastOffset(int yearsToGoBack = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? GetDefaultDate();
+         var maxDate = refDate ?? GetDate();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -92,7 +92,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTime Soon(int days = 1, DateTime? refDate = null)
       {
-         var dt = refDate ?? GetDefaultDate();
+         var dt = refDate ?? GetDate();
          return Between(dt, dt.AddDays(days));
       }
 
@@ -103,7 +103,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset SoonOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var dt = refDate ?? GetDefaultDate();
+         var dt = refDate ?? GetDate();
          return BetweenOffset(dt, dt.AddDays(days));
       }
 
@@ -114,7 +114,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Future(int yearsToGoForward = 1, DateTime? refDate = null)
       {
-         var minDate = refDate ?? GetDefaultDate();
+         var minDate = refDate ?? GetDate();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -132,7 +132,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset FutureOffset(int yearsToGoForward = 1, DateTimeOffset? refDate = null)
       {
-         var minDate = refDate ?? GetDefaultDate();
+         var minDate = refDate ?? GetDate();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -184,7 +184,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Recent(int days = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? GetDefaultDate();
+         var maxDate = refDate ?? GetDate();
 
          var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 
@@ -202,7 +202,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset RecentOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? GetDefaultDate();
+         var maxDate = refDate ?? GetDate();
 
          var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -7,6 +7,8 @@ namespace Bogus.DataSets
    /// </summary>
    public partial class Date : DataSet
    {
+      private readonly DateTime? _referenceDate;
+
       private bool hasMonthWideContext;
       private bool hasMonthAbbrContext;
       private bool hasWeekdayWideContext;
@@ -25,13 +27,17 @@ namespace Bogus.DataSets
       /// <summary>
       /// Create a Date dataset
       /// </summary>
-      public Date(string locale = "en") : base(locale)
+      public Date(DateTime? referenceDate = null, string locale = "en") : base(locale)
       {
+         _referenceDate = referenceDate;
+
          this.hasMonthWideContext = HasKey("month.wide_context", false);
          this.hasMonthAbbrContext = HasKey("month.abbr_context", false);
          this.hasWeekdayWideContext = HasKey("weekday.wide_context", false);
          this.hasWeekdayAbbrContext = HasKey("weekday.abbr_context", false);
       }
+
+      private DateTime GetDefaultDate() => GetDefaultDate();
 
       /// <summary>
       /// Get a <see cref="DateTime"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
@@ -40,7 +46,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Past(int yearsToGoBack = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetDefaultDate();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -58,7 +64,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset PastOffset(int yearsToGoBack = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetDefaultDate();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -86,7 +92,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTime Soon(int days = 1, DateTime? refDate = null)
       {
-         var dt = refDate ?? SystemClock();
+         var dt = refDate ?? GetDefaultDate();
          return Between(dt, dt.AddDays(days));
       }
 
@@ -97,7 +103,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset SoonOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var dt = refDate ?? SystemClock();
+         var dt = refDate ?? GetDefaultDate();
          return BetweenOffset(dt, dt.AddDays(days));
       }
 
@@ -108,7 +114,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Future(int yearsToGoForward = 1, DateTime? refDate = null)
       {
-         var minDate = refDate ?? SystemClock();
+         var minDate = refDate ?? GetDefaultDate();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -126,7 +132,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset FutureOffset(int yearsToGoForward = 1, DateTimeOffset? refDate = null)
       {
-         var minDate = refDate ?? SystemClock();
+         var minDate = refDate ?? GetDefaultDate();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -178,9 +184,9 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Recent(int days = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetDefaultDate();
 
-         var minDate = days == 0 ? SystemClock().Date : maxDate.AddDays(-days);
+         var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 
          var totalTimeSpanTicks = (maxDate - minDate).Ticks;
 
@@ -196,9 +202,9 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset RecentOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetDefaultDate();
 
-         var minDate = days == 0 ? SystemClock().Date : maxDate.AddDays(-days);
+         var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 
          var totalTimeSpanTicks = (maxDate - minDate).Ticks;
 

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -44,7 +44,11 @@ namespace Bogus.DataSets
          this.hasWeekdayAbbrContext = HasKey("weekday.abbr_context", false);
       }
 
-      private DateTime GetDate() => _referenceDate?.Invoke() ?? SystemClock();
+      /// <summary>
+      /// Get a <see cref="DateTime"/> of the reference time.
+      /// </summary>
+      /// <returns></returns>
+      public DateTime Now() => _referenceDate?.Invoke() ?? SystemClock();
 
       /// <summary>
       /// Get a <see cref="DateTime"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
@@ -53,7 +57,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Past(int yearsToGoBack = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? GetDate();
+         var maxDate = refDate ?? Now();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -71,7 +75,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset PastOffset(int yearsToGoBack = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? GetDate();
+         var maxDate = refDate ?? Now();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -99,7 +103,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTime Soon(int days = 1, DateTime? refDate = null)
       {
-         var dt = refDate ?? GetDate();
+         var dt = refDate ?? Now();
          return Between(dt, dt.AddDays(days));
       }
 
@@ -110,7 +114,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset SoonOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var dt = refDate ?? GetDate();
+         var dt = refDate ?? Now();
          return BetweenOffset(dt, dt.AddDays(days));
       }
 
@@ -121,7 +125,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Future(int yearsToGoForward = 1, DateTime? refDate = null)
       {
-         var minDate = refDate ?? GetDate();
+         var minDate = refDate ?? Now();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -139,7 +143,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset FutureOffset(int yearsToGoForward = 1, DateTimeOffset? refDate = null)
       {
-         var minDate = refDate ?? GetDate();
+         var minDate = refDate ?? Now();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -191,7 +195,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Recent(int days = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? GetDate();
+         var maxDate = refDate ?? Now();
 
          var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 
@@ -209,7 +213,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset RecentOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? GetDate();
+         var maxDate = refDate ?? Now();
 
          var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 

--- a/Source/Bogus/DataSets/Date.net60.cs
+++ b/Source/Bogus/DataSets/Date.net60.cs
@@ -31,7 +31,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly PastDateOnly(int yearsToGoBack = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(Now());
          var maxBehind = start.AddYears(-yearsToGoBack);
 
          return BetweenDateOnly(maxBehind, start);
@@ -44,7 +44,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly SoonDateOnly(int days = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(Now());
          var maxForward = start.AddDays(days);
 
          return BetweenDateOnly(start, maxForward);
@@ -57,7 +57,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly FutureDateOnly(int yearsToGoForward = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(Now());
          var maxForward = start.AddYears(yearsToGoForward);
 
          return BetweenDateOnly(start, maxForward);
@@ -70,7 +70,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly RecentDateOnly(int days = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(Now());
          var maxBehind = start.AddDays(-days);
 
          return BetweenDateOnly(maxBehind, start);
@@ -98,7 +98,7 @@ namespace Bogus.DataSets
       /// <param name="refTime">The time to start calculations. Default is time from <see cref="DateTime.Now"/>.</param>
       public TimeOnly SoonTimeOnly(int mins = 60, TimeOnly? refTime = null)
       {
-         var start = refTime ?? TimeOnly.FromDateTime(SystemClock());
+         var start = refTime ?? TimeOnly.FromDateTime(Now());
          var maxForward = start.AddMinutes(mins);
 
          return BetweenTimeOnly(start, maxForward);
@@ -111,7 +111,7 @@ namespace Bogus.DataSets
       /// <param name="refTime">The Time to start calculations. Default is time from <see cref="DateTime.Now"/>.</param>
       public TimeOnly RecentTimeOnly(int mins = 60, TimeOnly? refTime = null)
       {
-         var start = refTime ?? TimeOnly.FromDateTime(SystemClock());
+         var start = refTime ?? TimeOnly.FromDateTime(Now());
          var maxBehind = start.AddMinutes(-mins);
 
          return BetweenTimeOnly(maxBehind, start);

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -25,7 +25,7 @@ namespace Bogus
 
          this.Address = this.Notifier.Flow(new Address(locale));
          this.Company = this.Notifier.Flow(new Company(locale));
-         this.Date = this.Notifier.Flow(new Date (locale));
+         this.Date = this.Notifier.Flow(new Date (locale: locale));
          this.Finance = this.Notifier.Flow(new Finance {Locale = locale});
          this.Hacker = this.Notifier.Flow(new Hacker(locale));
          this.Image = this.Notifier.Flow(new Images(locale));

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -25,7 +25,7 @@ namespace Bogus
 
          this.Address = this.Notifier.Flow(new Address(locale));
          this.Company = this.Notifier.Flow(new Company(locale));
-         this.Date = this.Notifier.Flow(new Date(locale, () => ReferenceDate));
+         this.Date = this.Notifier.Flow(new Date(() => ReferenceDate, locale));
          this.Finance = this.Notifier.Flow(new Finance {Locale = locale});
          this.Hacker = this.Notifier.Flow(new Hacker(locale));
          this.Image = this.Notifier.Flow(new Images(locale));

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -101,7 +101,7 @@ namespace Bogus
       /// <summary>
       /// A contextually relevant fields of a person.
       /// </summary>
-      public Person Person => person ??= new Person(this.Random, this.Locale);
+      public Person Person => person ??= new Person(() => ReferenceDate, this.Random, this.Locale);
 
       /// <summary>
       /// Creates hacker gibberish.

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -25,7 +25,7 @@ namespace Bogus
 
          this.Address = this.Notifier.Flow(new Address(locale));
          this.Company = this.Notifier.Flow(new Company(locale));
-         this.Date = this.Notifier.Flow(new Date (locale: locale));
+         this.Date = this.Notifier.Flow(new Date(locale, () => ReferenceDate));
          this.Finance = this.Notifier.Flow(new Finance {Locale = locale});
          this.Hacker = this.Notifier.Flow(new Hacker(locale));
          this.Image = this.Notifier.Flow(new Images(locale));
@@ -325,6 +325,11 @@ namespace Bogus
       /// </summary>
       /// <value>The locale.</value>
       public string Locale { get; set; }
+
+      /// <summary>
+      /// Optional reference date for date generation
+      /// </summary>
+      public DateTime? ReferenceDate { get; set; }
 
       /// <summary>
       /// Triggers a new generation context

--- a/Source/Bogus/Person.cs
+++ b/Source/Bogus/Person.cs
@@ -55,9 +55,9 @@ namespace Bogus
       /// the Randomizer.Seed global static is ignored and a locally isolated derived seed is used to derive randomness.
       /// However, if the <paramref name="seed"/> parameter is null, then the Randomizer.Seed global static is used to derive randomness.
       /// </param>
-      public Person(string locale = "en", int? seed = null)
+      public Person(string locale = "en", int? seed = null, DateTime? referenceDate = null)
       {
-         this.GetDataSources(locale);
+         this.GetDataSources(() => referenceDate, locale);
          if( seed.HasValue )
          {
             this.Random = new Randomizer(seed.Value);
@@ -65,18 +65,22 @@ namespace Bogus
          this.Populate();
       }
 
-      internal Person(Randomizer randomizer, string locale = "en")
+      internal Person(Randomizer randomizer, string locale = "en") : this(null, randomizer, locale)
       {
-         this.GetDataSources(locale);
+      }
+
+      internal Person(Func<DateTime?> referenceDate, Randomizer randomizer, string locale = "en")
+      {
+         this.GetDataSources(referenceDate, locale);
          this.Random = randomizer;
          this.Populate();
       }
 
-      private void GetDataSources(string locale)
+      private void GetDataSources(Func<DateTime?> referenceDate, string locale)
       {
          this.DsName = this.Notifier.Flow(new Name(locale));
          this.DsInternet = this.Notifier.Flow(new Internet(locale));
-         this.DsDate = this.Notifier.Flow(new Date {Locale = locale});
+         this.DsDate = this.Notifier.Flow(new Date(referenceDate, locale));
          this.DsPhoneNumbers = this.Notifier.Flow(new PhoneNumbers(locale));
          this.DsAddress = this.Notifier.Flow(new Address(locale));
          this.DsCompany = this.Notifier.Flow(new Company(locale));

--- a/Source/Bogus/Person.cs
+++ b/Source/Bogus/Person.cs
@@ -94,7 +94,7 @@ namespace Bogus
          this.Website = this.DsInternet.DomainName();
          this.Avatar = this.DsInternet.Avatar();
 
-         this.DateOfBirth = this.DsDate.Past(50, Date.SystemClock().AddYears(-20));
+         this.DateOfBirth = this.DsDate.Past(50, DsDate.Now().AddYears(-20));
 
          this.Phone = this.DsPhoneNumbers.PhoneNumber();
 


### PR DESCRIPTION
The SystemClock is static and this is problematic if you have different reference dates. I wanted to provide the option to set the reference date on a faker as with the localization. The default is like before, nothing changes, therefore there should be no breaking change.

Example:
```
var f = new Faker();
f.ReferenceDate = new DateTime(2023, 12, 30, 12, 30, 0);
```