### PR TITLE
add tests for set clock and correct comment references

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
+## v34.0.3 (UNRELEASED @ master)
+Release Date: UNRELEASED
+* PR 500: Allows locally set time references for Date calculations instead of global statics. See Faker[T].UseDateTimeReference() and Date.LocalSystemClock.
+
 ## v34.0.2
 Release Date: 2022-03-27
+
 * PR 406, 415: Improve XML documentation. Thanks @danielwagn3r, @DanteDeRuwe
 * PR 413: Change access modifier of `Randomizer.localSeed` to protected. Thanks @davermaltby  
 

--- a/Source/Bogus.Tests/CloneTests.cs
+++ b/Source/Bogus.Tests/CloneTests.cs
@@ -1,36 +1,50 @@
 ﻿using FluentAssertions;
+using System;
 using Xunit;
 
 namespace Bogus.Tests
 {
    public class CloneTests : SeededTest
    {
+      public class Order
+      {
+         public int OrderId { get; set; }
+         public string Item { get; set; }
+         public int Quantity { get; set; }
+         public int? LotNumber { get; set; }
+         public DateTime Created { get; set; }
+      }
+
       [Fact]
       public void can_create_a_simple_clone()
       {
-         var orderFaker = new Faker<Examples.Order>()
+         var orderFaker = new Faker<Order>()
             .UseSeed(88)
+            .UseDateTimeReference(new DateTime(2022, 2, 2))
             .RuleFor(o => o.OrderId, f => f.IndexVariable++)
             .RuleFor(o => o.Quantity, f => f.Random.Number(1, 3))
-            .RuleFor(o => o.Item, f => f.Commerce.Product());
+            .RuleFor(o => o.Item, f => f.Commerce.Product())
+            .RuleFor(o => o.Created, f => f.Date.Recent());
 
          var clone = orderFaker.Clone();
 
          var clonedOrder = clone.Generate();
-
          var rootOrder = orderFaker.Generate();
 
          clonedOrder.Should().BeEquivalentTo(rootOrder);
+         clonedOrder.Created.Should().BeAtLeast(TimeSpan.FromDays(1));
       }
 
       [Fact]
       public void clone_has_different_rules()
       {
-         var rootFaker = new Faker<Examples.Order>()
+         var rootFaker = new Faker<Order>()
             .UseSeed(88)
+            .UseDateTimeReference(new DateTime(2022, 2, 2))
             .RuleFor(o => o.OrderId, f => f.IndexVariable++)
             .RuleFor(o => o.Quantity, f => f.Random.Number(1, 3))
-            .RuleFor(o => o.Item, f => f.Commerce.Product());
+            .RuleFor(o => o.Item, f => f.Commerce.Product())
+            .RuleFor(o => o.Created, f => f.Date.Recent());
 
          var cloneFaker = rootFaker.Clone()
             .RuleFor(o => o.Quantity, f => f.Random.Number(4, 6));

--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -348,6 +348,33 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void use_dataset_localclock_date_if_set()
+      {
+         var refDate = new DateTime(2009, 12, 30, 12, 30, 0);
+         var d = new Date() { LocalSystemClock = () => refDate };
+
+
+         d.Recent(0).Should()
+            .BeOnOrBefore(refDate)
+            .And
+            .BeOnOrAfter(refDate.Date);
+      }
+
+      [Fact]
+      public void use_now_param_over_localclock_date()
+      {
+         var refDate = new DateTime(2009, 12, 30, 12, 30, 0);
+         var now = DateTime.Now;
+
+         var d = new Date { LocalSystemClock = () => refDate };
+
+         d.Recent(0, now).Should()
+            .BeOnOrBefore(now)
+            .And
+            .BeOnOrAfter(now.Date);
+      }
+
+      [Fact]
       public void can_get_timezone_string()
       {
          date.TimeZoneString().Should().Be("Asia/Yerevan");

--- a/Source/Bogus.Tests/DataSetTests/DateTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.cs
@@ -51,6 +51,17 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_date_in_future_with_set_clock()
+      {
+         var refDate = DateTime.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate;
+         date.Future().Should()
+            .BeOnOrBefore(refDate.AddYears(1))
+            .And
+            .BeOnOrAfter(refDate);
+      }
+
+      [Fact]
       public void can_get_dateOffset_in_future()
       {
          var starting = DateTimeOffset.Parse("6/7/2015 4:17:41 PM");
@@ -58,6 +69,17 @@ namespace Bogus.Tests.DataSetTests
             .BeOnOrBefore(starting.AddYears(1))
             .And
             .BeOnOrAfter(starting);
+      }
+
+      [Fact]
+      public void can_get_dateOffset_in_future_with_set_clock()
+      {
+         var refDate = DateTimeOffset.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate.DateTime;
+         date.FutureOffset().Should()
+            .BeOnOrBefore(refDate.AddYears(1))
+            .And
+            .BeOnOrAfter(refDate);
       }
 
       [Fact]
@@ -91,6 +113,17 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_date_in_past_with_set_clock()
+      {
+         var refDate = DateTime.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate;
+         date.Past().Should()
+            .BeOnOrBefore(refDate)
+            .And
+            .BeOnOrAfter(refDate.AddYears(-1));
+      }
+
+      [Fact]
       public void can_get_dateOffset_in_past()
       {
          var starting = DateTimeOffset.Parse("6/7/2015 4:17:41 PM");
@@ -98,6 +131,17 @@ namespace Bogus.Tests.DataSetTests
             .BeOnOrBefore(starting)
             .And
             .BeOnOrAfter(starting.AddYears(-1));
+      }
+
+      [Fact]
+      public void can_get_dateOffset_in_past_with_set_clock()
+      {
+         var refDate = DateTimeOffset.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate.DateTime;
+         date.PastOffset().Should()
+            .BeOnOrBefore(refDate)
+            .And
+            .BeOnOrAfter(refDate.AddYears(-1));
       }
 
       [Fact]
@@ -150,6 +194,17 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_date_recently_with_set_clock()
+      {
+         var refDate = DateTime.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate;
+         date.Recent().Should()
+            .BeOnOrBefore(refDate)
+            .And
+            .BeOnOrAfter(refDate.AddDays(-1));
+      }
+
+      [Fact]
       public void can_get_dateOffset_recently_within_the_year()
       {
          var start = DateTimeOffset.Now;
@@ -158,6 +213,17 @@ namespace Bogus.Tests.DataSetTests
             .BeOnOrBefore(start)
             .And
             .BeOnOrAfter(start.AddDays(-1));
+      }
+
+      [Fact]
+      public void can_get_dateOffset_recently_with_set_clock()
+      {
+         var refDate = DateTimeOffset.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate.DateTime;
+         date.RecentOffset().Should()
+            .BeOnOrBefore(refDate)
+            .And
+            .BeOnOrAfter(refDate.AddDays(-1));
       }
 
       [Fact]
@@ -208,10 +274,32 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_date_soon_with_set_clock()
+      {
+         var refDate = DateTime.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate;
+         date.Soon().Should()
+            .BeOnOrAfter(refDate)
+            .And
+            .BeBefore(refDate.AddDays(1));
+      }
+
+      [Fact]
       public void get_a_dateOffsets_that_will_happen_soon()
       {
          var now = DateTimeOffset.Now;
          date.SoonOffset(3).Should().BeAfter(now).And.BeBefore(now.AddDays(3));
+      }
+
+      [Fact]
+      public void can_get_dateOffset_soon_with_set_clock()
+      {
+         var refDate = DateTimeOffset.Parse("6/7/2015 4:17:41 PM");
+         date.LocalSystemClock = () => refDate.DateTime;
+         date.SoonOffset().Should()
+            .BeOnOrAfter(refDate)
+            .And
+            .BeBefore(refDate.AddDays(1));
       }
 
       [Fact]

--- a/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
@@ -8,7 +8,7 @@ namespace Bogus.Tests.DataSetTests
 {
    public partial class DateTest
    {
-#if NET6_0
+#if NET6_0_OR_GREATER
       [Fact]
       public void can_get_dateonly_in_past()
       {

--- a/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
+++ b/Source/Bogus.Tests/DataSetTests/DateTest.net60.cs
@@ -20,6 +20,17 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_dateonly_in_past_with_set_clock()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddYears(-1);
+         date.LocalSystemClock = () => now.ToDateTime(new(0));
+
+         var somePastDate = date.PastDateOnly();
+         somePastDate.Should().BeInRange(maxBehind, now);
+      }
+
+      [Fact]
       public void can_get_dateonly_in_past_with_custom_options()
       {
          var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
@@ -42,12 +53,34 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_dateonly_that_will_happen_soon_with_set_clock()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxDate = now.AddDays(3);
+         date.LocalSystemClock = () => now.ToDateTime(new(0));
+
+         var someDateSoon = date.SoonDateOnly(3);
+         someDateSoon.Should().BeInRange(now, maxDate);
+      }
+
+      [Fact]
       public void can_get_dateonly_in_future()
       {
          var now = DateOnly.Parse("1/1/1990", CultureInfo.InvariantCulture);
          var maxDate = now.AddYears(1);
 
          var someFutureDate = date.FutureDateOnly(refDate: now);
+         someFutureDate.Should().BeInRange(now, maxDate);
+      }
+
+      [Fact]
+      public void can_get_dateonly_in_future_with_set_clock()
+      {
+         var now = DateOnly.Parse("1/1/1990", CultureInfo.InvariantCulture);
+         var maxDate = now.AddYears(1);
+         date.LocalSystemClock = () => now.ToDateTime(new(0));
+
+         var someFutureDate = date.FutureDateOnly();
          someFutureDate.Should().BeInRange(now, maxDate);
       }
 
@@ -83,6 +116,18 @@ namespace Bogus.Tests.DataSetTests
          var maxBehind = now.AddDays(-1);
 
          var someRecentDate = date.RecentDateOnly(refDate: now);
+
+         someRecentDate.Should().BeInRange(maxBehind, now);
+      }
+
+      [Fact]
+      public void can_get_dateonly_recently_within_the_year_with_set_clock()
+      {
+         var now = DateOnly.Parse("7/7/1972", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddDays(-1);
+         date.LocalSystemClock = () => now.ToDateTime(new(0));
+
+         var someRecentDate = date.RecentDateOnly();
 
          someRecentDate.Should().BeInRange(maxBehind, now);
       }
@@ -126,12 +171,35 @@ namespace Bogus.Tests.DataSetTests
       }
 
       [Fact]
+      public void can_get_a_timeonly_that_will_happen_soon_with_set_clock()
+      {
+         var now = TimeOnly.Parse("1:00 PM", CultureInfo.InvariantCulture);
+         var maxTime = now.AddMinutes(5);
+         date.LocalSystemClock = () => new DateOnly(1972, 7, 7).ToDateTime(now);
+
+         var timeSoon = date.SoonTimeOnly(5);
+
+         timeSoon.IsBetween(now, maxTime).Should().BeTrue();
+      }
+
+      [Fact]
       public void can_get_a_timeonly_that_happened_recently()
       {
          var now = TimeOnly.Parse("2:00 PM", CultureInfo.InvariantCulture);
          var maxBehind = now.AddMinutes(-5);
 
          var timeRecent = date.RecentTimeOnly(5, now);
+         timeRecent.IsBetween(maxBehind, now).Should().BeTrue();
+      }
+
+      [Fact]
+      public void can_get_a_timeonly_that_happened_recently_with_set_clock()
+      {
+         var now = TimeOnly.Parse("2:00 PM", CultureInfo.InvariantCulture);
+         var maxBehind = now.AddMinutes(-5);
+         date.LocalSystemClock = () => new DateOnly(1972, 7, 7).ToDateTime(now);
+
+         var timeRecent = date.RecentTimeOnly(5);
          timeRecent.IsBetween(maxBehind, now).Should().BeTrue();
       }
 #endif

--- a/Source/Bogus.Tests/GitHubIssues/PullRequest500.cs
+++ b/Source/Bogus.Tests/GitHubIssues/PullRequest500.cs
@@ -1,0 +1,141 @@
+﻿using Bogus.Tests.Models;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Bogus.Tests.GitHubIssues;
+
+public class PullRequest500 : SeededTest
+{
+   public class PersonTest
+   {
+      public string Name { get; set; }
+      public DateTime Birhtday { get; set; }
+   }
+
+   [Fact]
+   public void can_set_and_use_datetimereference_on_Faker()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+
+      var f = new Faker()
+      {
+         Random = new Randomizer(7331),
+         DateTimeReference = expected
+      };
+
+      f.Date.LocalSystemClock().Should().Be(expected);
+   }
+
+
+   [Fact]
+   public void can_set_and_use_datetimereference_on_FakerT()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+
+      var f = new Faker<Order>();
+      f.UseSeed(7331);
+      f.UseDateTimeReference(expected);
+
+      f.localDateTimeRef.Should().Be(expected);
+
+      var internals = f as IFakerTInternal;
+      internals.FakerHub.DateTimeReference.Should().NotBeNull();
+      internals.FakerHub.Date.LocalSystemClock().Should().Be(expected);
+   }
+
+
+   [Fact]
+   public void cloning_FakerT_still_uses_datetimereference_on_source_FakerT()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+
+      var fakerT = new Faker<Order>();
+      fakerT.UseSeed(7331);
+      fakerT.UseDateTimeReference(expected);
+
+      var clone = fakerT.Clone();
+
+      clone.localDateTimeRef.Should().Be(expected);
+
+      var cloneInternals = clone as IFakerTInternal;
+      cloneInternals.FakerHub.DateTimeReference.Should().NotBeNull();
+      cloneInternals.FakerHub.Date.LocalSystemClock().Should().Be(expected);
+   }
+
+   [Fact]
+   public void null_usedatetimereference_reverts_to_systemclock_FakerT()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+
+      var fakerT = new Faker<Order>();
+      fakerT.UseSeed(7331);
+      fakerT.UseDateTimeReference(expected);
+      fakerT.UseDateTimeReference(null);
+
+      fakerT.localDateTimeRef.Should().BeNull();
+
+      var internals = fakerT as IFakerTInternal;
+      internals.FakerHub.DateTimeReference.Should().BeNull();
+      internals.FakerHub.Date.LocalSystemClock.Should().BeNull();
+   }
+
+
+   [Fact]
+   public void null_datetimereference_should_use_systemclock_for_Faker()
+   {
+      var f = new Faker()
+      {
+         Random = new Randomizer(7331),
+         DateTimeReference = new System.DateTime(2017, 11, 11, 11, 11, 11)
+      };
+
+      f.DateTimeReference = null;
+
+      f.Date.LocalSystemClock.Should().BeNull();
+   }
+
+
+   [Fact]
+   public void FakerT_usedatetimereference_flows_to_Person()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+
+      var f = new Faker<PersonTest>()
+         .UseSeed(7331)
+         .UseDateTimeReference(expected)
+         .RuleFor(f => f.Name, f => f.Person.FirstName + " " + f.Person.LastName)
+         .RuleFor(f => f.Birhtday, f => f.Date.Recent());
+
+      var internals = f as IFakerTInternal;
+      internals.FakerHub.Person.DsDate.LocalSystemClock().Should().Be(expected);
+
+      var p = f.Generate();
+      p.Birhtday.Should().BeCloseTo(expected, precision: TimeSpan.FromDays(1));
+   }
+
+   [Fact]
+   public void using_Person_refDate_sets_dsdate_localsystemclock()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+      var p = new Bogus.Person(refDate: expected);
+      p.DsDate.LocalSystemClock.Should().NotBeNull();
+      p.DsDate.LocalSystemClock().Should().Be(expected);
+   }
+
+
+   [Fact]
+   public void using_internal_Person_refDate_sets_dsdate_localsystemclock()
+   {
+      var expected = new System.DateTime(2017, 11, 11, 11, 11, 11);
+      var p = new Bogus.Person(new Randomizer(), refDate: expected);
+      p.DsDate.LocalSystemClock.Should().NotBeNull();
+      p.DsDate.LocalSystemClock().Should().Be(expected);
+
+      p.DateOfBirth.Should()
+         .BeOnOrBefore(expected.AddYears(-20))
+         .And
+         .BeOnOrAfter(expected.AddYears(-20 + -50));
+   }
+
+}

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -236,6 +236,38 @@ namespace Bogus.Tests
       }
 
 
+      [Fact]
+      public void can_use_local_seed_and_refdate_for_person()
+      {
+         Date.SystemClock = () => DateTime.Now;
+
+         var p1 = new Person(seed: 1337, refDate: new DateTime(2019, 3, 21, 1, 1, 1));
+         var p2 = new Person(seed: 1337, refDate: new DateTime(2019, 3, 21, 1, 1, 1));
+         var q = new Person(seed: 7331, refDate: new DateTime(2019, 3, 21, 1, 1, 1));
+
+         q.DateOfBirth.Should().NotBe(p1.DateOfBirth);
+
+         p1.FullName.Should().Be("Samuel Haley");
+         p2.FullName.Should().Be(p1.FullName);
+         q.FullName.Should().Be("Lynette Beatty");
+         q.FullName.Should().NotBe(p1.FullName);
+
+         p1.FirstName.Should().Be(p2.FirstName);
+         p1.LastName.Should().Be(p2.LastName);
+         p1.Avatar.Should().Be(p2.Avatar);
+         p1.DateOfBirth.Should().Be(p2.DateOfBirth);
+         p1.Email.Should().Be(p2.Email);
+         p1.Phone.Should().Be(p2.Phone);
+         p1.UserName.Should().Be(p2.UserName);
+         p1.Gender.Should().Be(p2.Gender);
+         p1.Website.Should().Be(p2.Website);
+
+         p1.Should().BeEquivalentTo(p2, opts => opts.Excluding(p => p.DsDate.LocalSystemClock));
+
+         Date.SystemClock = () => DateTime.Now;
+      }
+
+
       IEnumerable<T> Get<T>(int times, Func<Person, T> a)
       {
          return Enumerable.Range(0, times)

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -54,6 +54,16 @@ namespace Bogus.Tests
       }
 
       [Fact]
+      public void pass_reference_date_to_person()
+      {
+         var now = DateTime.Parse("6/7/2020 4:17:41 PM");
+         var faker = new Faker<User>()
+            .UseDateTimeReference(now);
+
+         faker.FakerHub.Person.DsDate.GetTimeReference().Should().Be(now);
+      }
+
+      [Fact]
       public void can_generate_valid_sin()
       {
          var obtained = Get(10, p => p.Sin());
@@ -235,36 +245,18 @@ namespace Bogus.Tests
          Date.SystemClock = () => DateTime.Now;
       }
 
-
       [Fact]
-      public void can_use_local_seed_and_refdate_for_person()
+      public void can_use_refdate_for_person()
       {
          Date.SystemClock = () => DateTime.Now;
 
-         var p1 = new Person(seed: 1337, refDate: new DateTime(2019, 3, 21, 1, 1, 1));
-         var p2 = new Person(seed: 1337, refDate: new DateTime(2019, 3, 21, 1, 1, 1));
-         var q = new Person(seed: 7331, refDate: new DateTime(2019, 3, 21, 1, 1, 1));
+         var refDate = new DateTime(2019, 3, 21, 1, 1, 1);
+         var p1 = new Person(seed: 1337, refDate: refDate);
+         var p2 = new Person(seed: 1337, refDate: refDate);
+         var q = new Person(seed: 7331, refDate: refDate);
 
          q.DateOfBirth.Should().NotBe(p1.DateOfBirth);
-
-         p1.FullName.Should().Be("Samuel Haley");
-         p2.FullName.Should().Be(p1.FullName);
-         q.FullName.Should().Be("Lynette Beatty");
-         q.FullName.Should().NotBe(p1.FullName);
-
-         p1.FirstName.Should().Be(p2.FirstName);
-         p1.LastName.Should().Be(p2.LastName);
-         p1.Avatar.Should().Be(p2.Avatar);
          p1.DateOfBirth.Should().Be(p2.DateOfBirth);
-         p1.Email.Should().Be(p2.Email);
-         p1.Phone.Should().Be(p2.Phone);
-         p1.UserName.Should().Be(p2.UserName);
-         p1.Gender.Should().Be(p2.Gender);
-         p1.Website.Should().Be(p2.Website);
-
-         p1.Should().BeEquivalentTo(p2, opts => opts.Excluding(p => p.DsDate.LocalSystemClock));
-
-         Date.SystemClock = () => DateTime.Now;
       }
 
 

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -20,17 +20,22 @@ namespace Bogus.DataSets
       /// Setting this static value will effect and apply to all Faker[T], Faker,
       /// and new Date() datasets instances.
       /// </summary>
-      [Obsolete("Consider using new Faker[T].UseDateTimeReference(refDate), or new Faker(){ DateTimeReference = refDate } or new Date {LocalSystemClock = () => refDate}; all these options are scoped per object instance. Setting this global static system clock is considered bad practice and may be removed in the future.")]
+      [Obsolete("Consider using new Faker[T].UseDateTimeReference(refDate), or new Faker(){ DateTimeReference = refDate } or new Date {LocalSystemClock = () => refDate};" +
+         "all these options are scoped per object instance. Setting this global static system clock is considered bad practice and may be removed in the future.")]
       public static Func<DateTime> SystemClock = () => DateTime.Now;
 
       /// <summary>
       /// Sets the system clock time Bogus uses for date calculations.
       /// This value is normally <seealso cref="DateTime.Now"/>. If deterministic times are desired,
       /// set the <seealso cref="LocalSystemClock"/> to a single instance in time.
-      /// IE: () => new DateTime(2018, 4, 23);
       /// Setting this value will only effect and only apply to this single Date instance.
       /// </summary>
-      public Func<DateTime> LocalSystemClock = null;
+      /// <example>() => new DateTime(2018, 4, 23)</example>
+      public Func<DateTime> LocalSystemClock;
+
+      protected internal DateTime GetTimeReference() => LocalSystemClock?.Invoke() ?? SystemClock();
+
+      protected internal DateTimeOffset GetTimeReferenceOffset() => new DateTimeOffset(GetTimeReference());
 
       /// <summary>
       /// Create a Date dataset
@@ -43,13 +48,11 @@ namespace Bogus.DataSets
          this.hasWeekdayAbbrContext = HasKey("weekday.abbr_context", false);
       }
 
-      protected internal DateTime GetTimeReference() => LocalSystemClock?.Invoke() ?? SystemClock();
-
       /// <summary>
       /// Get a <see cref="DateTime"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
       /// </summary>
       /// <param name="yearsToGoBack">Years to go back from <paramref name="refDate"/>. Default is 1 year.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReference()"/>.</param>
       public DateTime Past(int yearsToGoBack = 1, DateTime? refDate = null)
       {
          var maxDate = refDate ?? GetTimeReference();
@@ -67,10 +70,10 @@ namespace Bogus.DataSets
       /// Get a <see cref="DateTimeOffset"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
       /// </summary>
       /// <param name="yearsToGoBack">Years to go back from <paramref name="refDate"/>. Default is 1 year.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReferenceOffset()"/>.</param>
       public DateTimeOffset PastOffset(int yearsToGoBack = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? GetTimeReference();
+         var maxDate = refDate ?? GetTimeReferenceOffset();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -95,7 +98,7 @@ namespace Bogus.DataSets
       /// Get a <see cref="DateTime"/> that will happen soon.
       /// </summary>
       /// <param name="days">A date no more than <paramref name="days"/> ahead.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReference()"/>.</param>
       public DateTime Soon(int days = 1, DateTime? refDate = null)
       {
          var dt = refDate ?? GetTimeReference();
@@ -106,10 +109,10 @@ namespace Bogus.DataSets
       /// Get a <see cref="DateTimeOffset"/> that will happen soon.
       /// </summary>
       /// <param name="days">A date no more than <paramref name="days"/> ahead.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReferenceOffset()"/>.</param>
       public DateTimeOffset SoonOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var dt = refDate ?? GetTimeReference();
+         var dt = refDate ?? GetTimeReferenceOffset();
          return BetweenOffset(dt, dt.AddDays(days));
       }
 
@@ -117,7 +120,7 @@ namespace Bogus.DataSets
       /// Get a <see cref="DateTime"/> in the future between <paramref name="refDate"/> and <paramref name="yearsToGoForward"/>.
       /// </summary>
       /// <param name="yearsToGoForward">Years to go forward from <paramref name="refDate"/>. Default is 1 year.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReference()"/>.</param>
       public DateTime Future(int yearsToGoForward = 1, DateTime? refDate = null)
       {
          var minDate = refDate ?? GetTimeReference();
@@ -135,10 +138,10 @@ namespace Bogus.DataSets
       /// Get a <see cref="DateTimeOffset"/> in the future between <paramref name="refDate"/> and <paramref name="yearsToGoForward"/>.
       /// </summary>
       /// <param name="yearsToGoForward">Years to go forward from <paramref name="refDate"/>. Default is 1 year.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReferenceOffset"/>.</param>
       public DateTimeOffset FutureOffset(int yearsToGoForward = 1, DateTimeOffset? refDate = null)
       {
-         var minDate = refDate ?? GetTimeReference();
+         var minDate = refDate ?? GetTimeReferenceOffset();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -187,7 +190,7 @@ namespace Bogus.DataSets
       /// Get a random <see cref="DateTime"/> within the last few days.
       /// </summary>
       /// <param name="days">Number of days to go back.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReference()"/>.</param>
       public DateTime Recent(int days = 1, DateTime? refDate = null)
       {
          var maxDate = refDate ?? GetTimeReference();
@@ -205,10 +208,10 @@ namespace Bogus.DataSets
       /// Get a random <see cref="DateTimeOffset"/> within the last few days.
       /// </summary>
       /// <param name="days">Number of days to go back.</param>
-      /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
+      /// <param name="refDate">The date to start calculations. Default is <see cref="GetTimeReferenceOffset()"/>.</param>
       public DateTimeOffset RecentOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? GetTimeReference();
+         var maxDate = refDate ?? GetTimeReferenceOffset();
 
          var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 

--- a/Source/Bogus/DataSets/Date.cs
+++ b/Source/Bogus/DataSets/Date.cs
@@ -20,7 +20,17 @@ namespace Bogus.DataSets
       /// Setting this static value will effect and apply to all Faker[T], Faker,
       /// and new Date() datasets instances.
       /// </summary>
+      [Obsolete("Consider using new Faker[T].UseDateTimeReference(refDate), or new Faker(){ DateTimeReference = refDate } or new Date {LocalSystemClock = () => refDate}; all these options are scoped per object instance. Setting this global static system clock is considered bad practice and may be removed in the future.")]
       public static Func<DateTime> SystemClock = () => DateTime.Now;
+
+      /// <summary>
+      /// Sets the system clock time Bogus uses for date calculations.
+      /// This value is normally <seealso cref="DateTime.Now"/>. If deterministic times are desired,
+      /// set the <seealso cref="LocalSystemClock"/> to a single instance in time.
+      /// IE: () => new DateTime(2018, 4, 23);
+      /// Setting this value will only effect and only apply to this single Date instance.
+      /// </summary>
+      public Func<DateTime> LocalSystemClock = null;
 
       /// <summary>
       /// Create a Date dataset
@@ -33,6 +43,8 @@ namespace Bogus.DataSets
          this.hasWeekdayAbbrContext = HasKey("weekday.abbr_context", false);
       }
 
+      protected internal DateTime GetTimeReference() => LocalSystemClock?.Invoke() ?? SystemClock();
+
       /// <summary>
       /// Get a <see cref="DateTime"/> in the past between <paramref name="refDate"/> and <paramref name="yearsToGoBack"/>.
       /// </summary>
@@ -40,7 +52,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Past(int yearsToGoBack = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetTimeReference();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -58,7 +70,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset PastOffset(int yearsToGoBack = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetTimeReference();
 
          var minDate = maxDate.AddYears(-yearsToGoBack);
 
@@ -86,7 +98,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTime Soon(int days = 1, DateTime? refDate = null)
       {
-         var dt = refDate ?? SystemClock();
+         var dt = refDate ?? GetTimeReference();
          return Between(dt, dt.AddDays(days));
       }
 
@@ -97,7 +109,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset SoonOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var dt = refDate ?? SystemClock();
+         var dt = refDate ?? GetTimeReference();
          return BetweenOffset(dt, dt.AddDays(days));
       }
 
@@ -108,7 +120,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Future(int yearsToGoForward = 1, DateTime? refDate = null)
       {
-         var minDate = refDate ?? SystemClock();
+         var minDate = refDate ?? GetTimeReference();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -126,7 +138,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset FutureOffset(int yearsToGoForward = 1, DateTimeOffset? refDate = null)
       {
-         var minDate = refDate ?? SystemClock();
+         var minDate = refDate ?? GetTimeReference();
 
          var maxDate = minDate.AddYears(yearsToGoForward);
 
@@ -178,9 +190,9 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTime.Now"/>.</param>
       public DateTime Recent(int days = 1, DateTime? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetTimeReference();
 
-         var minDate = days == 0 ? SystemClock().Date : maxDate.AddDays(-days);
+         var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 
          var totalTimeSpanTicks = (maxDate - minDate).Ticks;
 
@@ -196,9 +208,9 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is <see cref="DateTimeOffset.Now"/>.</param>
       public DateTimeOffset RecentOffset(int days = 1, DateTimeOffset? refDate = null)
       {
-         var maxDate = refDate ?? SystemClock();
+         var maxDate = refDate ?? GetTimeReference();
 
-         var minDate = days == 0 ? SystemClock().Date : maxDate.AddDays(-days);
+         var minDate = days == 0 ? maxDate.Date : maxDate.AddDays(-days);
 
          var totalTimeSpanTicks = (maxDate - minDate).Ticks;
 

--- a/Source/Bogus/DataSets/Date.net60.cs
+++ b/Source/Bogus/DataSets/Date.net60.cs
@@ -7,7 +7,7 @@ namespace Bogus.DataSets
 {
    public partial class Date
    {
-#if NET6_0
+#if NET6_0_OR_GREATER
       /// <summary>
       /// Get a random <see cref="DateOnly"/> between <paramref name="start"/> and <paramref name="end"/>.
       /// </summary>
@@ -31,7 +31,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly PastDateOnly(int yearsToGoBack = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(GetTimeReference());
          var maxBehind = start.AddYears(-yearsToGoBack);
 
          return BetweenDateOnly(maxBehind, start);
@@ -44,7 +44,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly SoonDateOnly(int days = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(GetTimeReference());
          var maxForward = start.AddDays(days);
 
          return BetweenDateOnly(start, maxForward);
@@ -57,7 +57,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly FutureDateOnly(int yearsToGoForward = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(GetTimeReference());
          var maxForward = start.AddYears(yearsToGoForward);
 
          return BetweenDateOnly(start, maxForward);
@@ -70,7 +70,7 @@ namespace Bogus.DataSets
       /// <param name="refDate">The date to start calculations. Default is from <see cref="DateTime.Now"/>.</param>
       public DateOnly RecentDateOnly(int days = 1, DateOnly? refDate = null)
       {
-         var start = refDate ?? DateOnly.FromDateTime(SystemClock());
+         var start = refDate ?? DateOnly.FromDateTime(GetTimeReference());
          var maxBehind = start.AddDays(-days);
 
          return BetweenDateOnly(maxBehind, start);
@@ -98,7 +98,7 @@ namespace Bogus.DataSets
       /// <param name="refTime">The time to start calculations. Default is time from <see cref="DateTime.Now"/>.</param>
       public TimeOnly SoonTimeOnly(int mins = 60, TimeOnly? refTime = null)
       {
-         var start = refTime ?? TimeOnly.FromDateTime(SystemClock());
+         var start = refTime ?? TimeOnly.FromDateTime(GetTimeReference());
          var maxForward = start.AddMinutes(mins);
 
          return BetweenTimeOnly(start, maxForward);
@@ -111,7 +111,7 @@ namespace Bogus.DataSets
       /// <param name="refTime">The Time to start calculations. Default is time from <see cref="DateTime.Now"/>.</param>
       public TimeOnly RecentTimeOnly(int mins = 60, TimeOnly? refTime = null)
       {
-         var start = refTime ?? TimeOnly.FromDateTime(SystemClock());
+         var start = refTime ?? TimeOnly.FromDateTime(GetTimeReference());
          var maxBehind = start.AddMinutes(-mins);
 
          return BetweenTimeOnly(maxBehind, start);

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -101,7 +101,39 @@ namespace Bogus
       /// <summary>
       /// A contextually relevant fields of a person.
       /// </summary>
-      public Person Person => person ??= new Person(this.Random, this.Locale);
+      public Person Person => person ??= new Person(this.Random, this.localDateTimeRef, this.Locale);
+
+
+      private DateTime? localDateTimeRef;
+
+      /// <summary>
+      /// The fixed point in time DateTime reference used for date and time calculations
+      /// with this Faker instance and the underlying .Date dataset. If this property is set to null,
+      /// then the .Date dataset's static system clock is usually used.
+      /// 
+      /// Typically this property is set when Faker[T].UseDateTimeReference() is called,
+      /// or is set manually when creating an instance of new Faker { DateTimeReference = new DateTime(year, month, day) }.
+      /// When this property is set, all date/time calculations from .Date will begin calculations from this fixed point in time for this Faker instance.
+      /// </summary>
+      public DateTime? DateTimeReference
+      {
+         get
+         {
+            return localDateTimeRef;
+         }
+         set
+         {
+            localDateTimeRef = value;
+            if( localDateTimeRef.HasValue )
+            {
+               this.Date.LocalSystemClock = () => localDateTimeRef.Value;
+            }
+            else
+            {
+               this.Date.LocalSystemClock = null;
+            }
+         }
+      }
 
       /// <summary>
       /// Creates hacker gibberish.

--- a/Source/Bogus/Faker[T].cs
+++ b/Source/Bogus/Faker[T].cs
@@ -60,6 +60,7 @@ namespace Bogus
       protected internal bool? IsValid;
       protected internal string currentRuleSet = Default;
       protected internal int? localSeed; // if null, the global Randomizer.Seed is used.
+      protected internal DateTime? localDateTimeRef;
 #pragma warning restore 1591
 
       Faker IFakerTInternal.FakerHub => this.FakerHub;
@@ -111,6 +112,11 @@ namespace Bogus
             clone.UseSeed(localSeed.Value);
          }
 
+         if( localDateTimeRef.HasValue )
+         {
+            clone.UseDateTimeReference(localDateTimeRef.Value);
+         }
+
          return clone;
       }
 
@@ -156,6 +162,19 @@ namespace Bogus
       {
          this.localSeed = seed;
          this.FakerHub.Random = new Randomizer(seed);
+         return this;
+      }
+
+      /// <summary>
+      /// Sets a local time reference for all Date time calculations used by
+      /// this Faker[T] instance; unless refDate parameters are specified 
+      /// with the corresponding Date.Methods().
+      /// </summary>
+      /// <param name="refDate">The anchored DateTime reference to use.</param>
+      public virtual Faker<T> UseDateTimeReference(DateTime? refDate)
+      {
+         this.localDateTimeRef = refDate;
+         this.FakerHub.DateTimeReference = refDate;
          return this;
       }
 

--- a/Source/Bogus/Faker[T].cs
+++ b/Source/Bogus/Faker[T].cs
@@ -166,8 +166,8 @@ namespace Bogus
       }
 
       /// <summary>
-      /// Sets a local time reference for all Date time calculations used by
-      /// this Faker[T] instance; unless refDate parameters are specified 
+      /// Sets a local time reference for all DateTime calculations used by
+      /// this <see cref="Faker{T}"/> instance; unless <paramref name="refDate"/> parameters are specified 
       /// with the corresponding Date.Methods().
       /// </summary>
       /// <param name="refDate">The anchored DateTime reference to use.</param>

--- a/Source/Bogus/Person.cs
+++ b/Source/Bogus/Person.cs
@@ -40,12 +40,12 @@ namespace Bogus
          public string Bs;
       }
 
-      protected Name DsName { get; set; }
-      protected Internet DsInternet { get; set; }
-      protected Date DsDate { get; set; }
-      protected PhoneNumbers DsPhoneNumbers { get; set; }
-      protected Address DsAddress { get; set; }
-      protected Company DsCompany { get; set; }
+      protected internal Name DsName { get; set; }
+      protected internal Internet DsInternet { get; set; }
+      protected internal Date DsDate { get; set; }
+      protected internal PhoneNumbers DsPhoneNumbers { get; set; }
+      protected internal Address DsAddress { get; set; }
+      protected internal Company DsCompany { get; set; }
 
       /// <summary>
       /// Creates a new Person object.
@@ -55,20 +55,28 @@ namespace Bogus
       /// the Randomizer.Seed global static is ignored and a locally isolated derived seed is used to derive randomness.
       /// However, if the <paramref name="seed"/> parameter is null, then the Randomizer.Seed global static is used to derive randomness.
       /// </param>
-      public Person(string locale = "en", int? seed = null)
+      public Person(string locale = "en", int? seed = null, DateTime? refDate = null)
       {
          this.GetDataSources(locale);
          if( seed.HasValue )
          {
             this.Random = new Randomizer(seed.Value);
          }
+         if( refDate.HasValue )
+         {
+            this.DsDate.LocalSystemClock = () => refDate.Value;
+         }
          this.Populate();
       }
 
-      internal Person(Randomizer randomizer, string locale = "en")
+      internal Person(Randomizer randomizer, DateTime? refDate, string locale = "en")
       {
          this.GetDataSources(locale);
          this.Random = randomizer;
+         if( refDate.HasValue )
+         {
+            this.DsDate.LocalSystemClock = () => refDate.Value;
+         }
          this.Populate();
       }
 
@@ -94,7 +102,7 @@ namespace Bogus
          this.Website = this.DsInternet.DomainName();
          this.Avatar = this.DsInternet.Avatar();
 
-         this.DateOfBirth = this.DsDate.Past(50, Date.SystemClock().AddYears(-20));
+         this.DateOfBirth = this.DsDate.Past(50, this.DsDate.GetTimeReference().AddYears(-20));
 
          this.Phone = this.DsPhoneNumbers.PhoneNumber();
 


### PR DESCRIPTION
- Add tests to verify all changes in the Date DataSet operations that make use of the ReferenceTime
- Use DateTimeOffset for DateTimeOffset methods
- Fix comment references