### PR TITLE
Remove diacritics from method names in Bogus; fixes #497

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## v35.2.0
+Release Date: 2023-12-26
+* Issue 497: PR 522 - Better Xamarin AOT compatibility. Renames/removes diacritics from API method names Finland: Henkilötunnus -> Henkilotunnus; Norway: Fødselsnummer -> Fodselsnummer.
+
 ## v35.0.1
 Release Date: 2023-12-11
 * PR 513: Update Swedish `sv` locale; first/last names. Thanks @EBD232!

--- a/README.md
+++ b/README.md
@@ -505,12 +505,12 @@ In the examples above, all three alternative styles of using **Bogus** produce t
 * **`using Bogus.Extensions.Denmark;`**
 	* `Bogus.Person.Cpr()` - Danish Personal Identification number
 * **`using Bogus.Extensions.Finland;`**
-	* `Bogus.Person.Henkilötunnus()` - Finnish Henkilötunnus
+	* `Bogus.Person.Henkilotunnus()` - Finnish Henkilötunnus
 * **`using Bogus.Extensions.Italy;`**
 	* `Bogus.Person.CodiceFiscale()` - Codice Fiscale
 	* `Bogus.DataSets.Finance.CodiceFiscale()` - Codice Fiscale
 * **`using Bogus.Extensions.Norway;`**
-	* `Bogus.Person.Fødselsnummer()` - Norwegian national identity number
+	* `Bogus.Person.Fodselsnummer()` - Norwegian national identity number
 * **`using Bogus.Extensions.Portugal;`**
 	* `Bogus.Person.Nif()` - Número de Identificação Fiscal (NIF)
 	* `Bogus.DataSets.Company.Nipc()` - Número de Identificação de Pessoa Colectiva (NIPC)

--- a/Source/Bogus.Tests/ExtensionTests/NorwegianExtensionTest.cs
+++ b/Source/Bogus.Tests/ExtensionTests/NorwegianExtensionTest.cs
@@ -88,7 +88,7 @@ public class NorwegianExtensionTest : SeededTest
       var f = new Faker("nb_NO");
       var person = f.Person;
 
-      string fødselsnummer = person.Fødselsnummer();
+      string fødselsnummer = person.Fodselsnummer();
 
       IsLegalFødselsnummer(fødselsnummer, person);
    }

--- a/Source/Bogus.Tests/PersonTest.cs
+++ b/Source/Bogus.Tests/PersonTest.cs
@@ -168,7 +168,7 @@ public class PersonTest : SeededTest
    public void can_generate_henkilötunnus_for_finland()
    {
       var p = new Person();
-      var obtained = p.Henkilötunnus();
+      var obtained = p.Henkilotunnus();
 
       var a = obtained.Split('-')[0];
       var b = obtained.Split('-')[1];

--- a/Source/Bogus/Extensions/ExtensionsForString.cs
+++ b/Source/Bogus/Extensions/ExtensionsForString.cs
@@ -53,7 +53,7 @@ public static class ExtensionsForString
    }
 
    /// <summary>
-   /// Transliterates Unicode characters to US-ASCII. For example, Russian cryllic "Анна Фомина" becomes "Anna Fomina".
+   /// Transliterates Unicode characters to US-ASCII. For example, Russian cyrillic "Анна Фомина" becomes "Anna Fomina".
    /// </summary>
    /// <param name="this">The @this string to act on.</param>
    /// <param name="lang">The language character set to use.</param>

--- a/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
+++ b/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
@@ -8,7 +8,7 @@ public static class ExtensionsForFinland
    /// <summary>
    /// Finnish Henkilötunnus
    /// </summary>
-   public static string Henkilötunnus(this Person p)
+   public static string Henkilotunnus(this Person p)
    {
       const string Key = nameof(ExtensionsForFinland) + "Henkilötunnus";
       if( p.context.ContainsKey(Key) )

--- a/Source/Bogus/Extensions/Norway/ExtensionsForNorway.cs
+++ b/Source/Bogus/Extensions/Norway/ExtensionsForNorway.cs
@@ -8,9 +8,9 @@ namespace Bogus.Extensions.Norway;
 public static class ExtensionsForNorway
 {
    /// <summary>
-   /// Norwegian national identity number
+   /// Fødselsnummer - Norwegian national identity number
    /// </summary>
-   public static string Fødselsnummer(this Person p)
+   public static string Fodselsnummer(this Person p)
    {
       const string Key = nameof(ExtensionsForNorway) + "Fødselsnummer";
       if (p.context.ContainsKey(Key))


### PR DESCRIPTION
Fixes #497; removes diacritics from API method names in Bogus; Improves AOT compatability