### PR TITLE
Fix for issue #534: Gender-digit is incorrect for Swedish Personnummer generation

### DIFF
--- a/Source/Bogus.Tests/ExtensionTests/SwedishExtensionTest.cs
+++ b/Source/Bogus.Tests/ExtensionTests/SwedishExtensionTest.cs
@@ -60,7 +60,7 @@ public class SwedishExtensionTest : SeededTest
    [Theory]
    [InlineData(false)]
    [InlineData(true)]
-   public void when_person_is_male_second_last_number_is_even(bool isSamordningsnummer)
+   public void when_person_is_male_second_last_number_is_odd(bool isSamordningsnummer)
    {
       var f = new Faker("sv");
       var person = f.Person;
@@ -71,7 +71,7 @@ public class SwedishExtensionTest : SeededTest
       var secondLast = int.Parse(identificationNumber.Substring(identificationNumber.Length - 2, 1));
 
       secondLast.Should()
-         .Match(x => x % 2 == 0)
+         .Match(x => x % 2 == 1)
          .And.BeLessThan(10)
          .And.BeGreaterThan(0);
    }
@@ -79,7 +79,7 @@ public class SwedishExtensionTest : SeededTest
    [Theory]
    [InlineData(false)]
    [InlineData(true)]
-   public void when_person_is_female_second_last_number_is_odd(bool isSamordningsnummer)
+   public void when_person_is_female_second_last_number_is_even(bool isSamordningsnummer)
    {
       var f = new Faker("sv");
       var person = f.Person;
@@ -90,7 +90,7 @@ public class SwedishExtensionTest : SeededTest
       var secondLast = int.Parse(identificationNumber.Substring(identificationNumber.Length - 2, 1));
 
       secondLast.Should()
-         .Match(x => x % 2 == 1)
+         .Match(x => x % 2 == 0)
          .And.BeLessThan(10)
          .And.BeGreaterThan(0);
    }

--- a/Source/Bogus/Extensions/Sweden/ExtensionsForSweden.cs
+++ b/Source/Bogus/Extensions/Sweden/ExtensionsForSweden.cs
@@ -48,7 +48,7 @@ public static class ExtensionsForSweden
    /// </summary>
    /// <remarks>
    /// Coordination numbers enable Swedish public authorities and other organizations with a public function 
-   /// to identify people who are not currently � and have never been � registered at an address in Sweden.
+   /// to identify people who are not currently – and have never been – registered at an address in Sweden.
    /// </remarks>
    public static string Samordningsnummer(this Person person)
    {

--- a/Source/Bogus/Extensions/Sweden/ExtensionsForSweden.cs
+++ b/Source/Bogus/Extensions/Sweden/ExtensionsForSweden.cs
@@ -48,7 +48,7 @@ public static class ExtensionsForSweden
    /// </summary>
    /// <remarks>
    /// Coordination numbers enable Swedish public authorities and other organizations with a public function 
-   /// to identify people who are not currently – and have never been – registered at an address in Sweden.
+   /// to identify people who are not currently ï¿½ and have never been ï¿½ registered at an address in Sweden.
    /// </remarks>
    public static string Samordningsnummer(this Person person)
    {
@@ -90,9 +90,9 @@ public static class ExtensionsForSweden
    private static int GetGenderNumber(Randomizer r, Gender gender)
    {
       if( gender is Gender.Male )
-         return r.Even(1, 9);
-      if( gender is Gender.Female )
          return r.Odd(1, 9);
+      if( gender is Gender.Female )
+         return r.Even(1, 9);
       throw new ArgumentOutOfRangeException(nameof(gender), gender, "Gender not handled.");
    }
 


### PR DESCRIPTION
For a Swedish Personnummer (social security number), the last digit is a Luhn-checksum. The second last digit is odd for a person with male legal gender and even for a person with female legal gender.
You can read about it here:
https://skatteverket.se/privat/folkbokforing/personnummer.4.3810a01c150939e893f18c29.html
The implementation in ExtensionsForSweden.cs was implemented the other way around for male/female.
This PR fixes the gender digit and the corresponding unit tests.

