### PR TITLE
Use Lazy for expensive properties in System Dataset

### DIFF
--- a/Source/Bogus/DataSets/System.cs
+++ b/Source/Bogus/DataSets/System.cs
@@ -17,41 +17,47 @@ public class System : DataSet
    /// <param name="locale">The locale that will be used to generate values.</param>
    public System(string locale = "en") : base(locale)
    {
-      mimes = this.GetArray("mimeTypes");
+      mimes = new Lazy<BArray>(
+         () => this.GetArray("mimeTypes"));
 
-      lookup = mimes.OfType<BObject>()
-         .ToDictionary(o => o["mime"].StringValue);
-
-      mimeKeys = mimes
-         .OfType<BObject>()
-         .Select(o => o["mime"].StringValue)
-         .Distinct()
-         .ToArray();
-
-      exts = mimes
-         .OfType<BObject>()
-         .SelectMany(bObject =>
+      lookup = new Lazy<Dictionary<string, BObject>>(
+         () => mimes.Value.OfType<BObject>()
+            .ToDictionary(o => o["mime"].StringValue));
+      
+      mimeKeys = new Lazy<string[]>(
+         () => mimes.Value
+            .OfType<BObject>()
+            .Select(o => o["mime"].StringValue)
+            .Distinct()
+            .ToArray());
+      
+      exts = new Lazy<string[]>(
+         () => mimes.Value
+            .OfType<BObject>()
+            .SelectMany(bObject =>
             {
-               if( bObject.ContainsKey("extensions") )
+               if (bObject.ContainsKey("extensions"))
                {
                   var extensions = bObject["extensions"] as BArray;
                   return extensions.OfType<BValue>().Select(s => s.StringValue);
                }
+               
                return Enumerable.Empty<string>();
             })
-         .ToArray();
-
-      types = mimeKeys.Select(k => k.Substring(0, k.IndexOf('/')))
-         .Distinct()
-         .ToArray();
+            .ToArray());
+      
+      types = new Lazy<string[]>(
+         () => mimeKeys.Value.Select(k => k.Substring(0, k.IndexOf('/')))
+            .Distinct()
+            .ToArray());
    }
 
    protected Lorem Lorem = null;
-   private readonly Dictionary<string, BObject> lookup;
-   private readonly BArray mimes;
-   private readonly string[] exts;
-   private readonly string[] types;
-   private readonly string[] mimeKeys;
+   private readonly Lazy<Dictionary<string, BObject>> lookup;
+   private readonly Lazy<BArray> mimes;
+   private readonly Lazy<string[]> exts;
+   private readonly Lazy<string[]> types;
+   private readonly Lazy<string[]> mimeKeys;
 
    private static readonly string[] commonFileTypes = 
       { "video", "audio", "image", "text", "application" };
@@ -145,7 +151,7 @@ public class System : DataSet
    /// </returns>
    public string MimeType()
    {
-      return this.Random.ArrayElement(this.mimeKeys);
+      return this.Random.ArrayElement(this.mimeKeys.Value);
    }
 
 
@@ -181,7 +187,7 @@ public class System : DataSet
    /// </returns>
    public string FileType()
    {
-      return this.Random.ArrayElement(this.types);
+      return this.Random.ArrayElement(this.types.Value);
    }
 
 
@@ -194,13 +200,13 @@ public class System : DataSet
    public string FileExt(string mimeType = null)
    {
       if( mimeType != null &&
-          lookup.TryGetValue(mimeType, out var mime) &&
+          lookup.Value.TryGetValue(mimeType, out var mime) &&
           mime.ContainsKey("extensions") )
       {
          return this.Random.ArrayElement(mime["extensions"] as BArray);
       }
 
-      return this.Random.ArrayElement(exts);
+      return this.Random.ArrayElement(exts.Value);
    }
 
    /// <summary>


### PR DESCRIPTION
In my tests with repeated creation (clones) of Faker instances, the creation of this dataset was by far the most expensive one. Making it lazy should alleviate a lot of GC pressure, until the Dataset is actually used.

For my benchmark I ran 100 generators in parallel, each of which creating ~100 Fakers. The fakers are cloned from a static base config. A generator has all the configs needed to create all the data needed for our app, which it does.
This should also be reproducible with a simpler setup. That would probably drop the lazy version to even lower allocations as there wouldn't be that much data generated from it.

```

BenchmarkDotNet v0.13.12, Arch Linux
AMD Ryzen 9 7940HS w/ Radeon 780M Graphics, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.104
  [Host]     : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  DefaultJob : .NET 8.0.4 (8.0.424.16909), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI


```
| Method                            | Mean     | Error    | StdDev   | Gen0        | Gen1       | Gen2      | Allocated |
|---------------------------------- |---------:|---------:|---------:|------------:|-----------:|----------:|----------:|
| RunBogusGeneratorInParallel | 961.9 ms | 18.84 ms | 22.43 ms | 125000.0000 | 59000.0000 | 1000.0000 | 931.62 MB |
| RunBogusGeneratorInParallel | 309.4 ms | 7.10 ms | 20.26 ms | 21000.0000 | 7000.0000 | 1000.0000 | 154.46 MB |


Is there anything that would speak against this change? It speeds up data generation a lot in cases like mine without sacrificing functionality. Tests all passed without issues, too.