### PR TITLE
Added support for Vietnamese Citizen Identity Card Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,8 @@ In the examples above, all three alternative styles of using **Bogus** produce t
 * **`using Bogus.Extensions.UnitedStates;`**
 	* `Bogus.Person.Ssn()` - Social Security Number
 	* `Bogus.DataSets.Company.Ein()` - Employer Identification Number
+* **`using Bogus.Extensions.Vietnam;`**
+  * `Bogus.Person.Cccd()` - Vietnamese Citizen Identity Card Number (Căn Cước Công Dân - CCCD)
 * **`using Bogus.Distributions.Gaussian;`**
     * `Randomizer.GaussianInt()` - Generate an `int` based on a specific normal distribution.
     * `Randomizer.GaussianFloat()` - Generate a `float` based on a specific normal distribution.

--- a/Source/Bogus.Tests/ExtensionTests/VietnameseExtensionTest.cs
+++ b/Source/Bogus.Tests/ExtensionTests/VietnameseExtensionTest.cs
@@ -1,0 +1,143 @@
+using System;
+using Bogus.DataSets;
+using Bogus.Extensions.Vietnam;
+using FluentAssertions;
+using Xunit;
+
+namespace Bogus.Tests.ExtensionTests;
+
+public class VietnameseExtensionTest : SeededTest
+{
+   #region Setup test cases
+
+   public static TheoryData<int, Name.Gender, string> ValidVietnameseCitizenIdTestCases => new()
+   {
+      { 1990, Name.Gender.Male, "Hà Nội" },
+      { 1999, Name.Gender.Female, "An Giang" },
+      { 2000, Name.Gender.Male, "TP. Hồ Chí Minh" },
+      { 2001, Name.Gender.Female, "Bà Rịa-Vũng Tàu" }
+   };
+   
+   public static TheoryData<int, Name.Gender, string> InvalidVietnameseCitizenIdTestCases => new()
+   {
+      { 1899, Name.Gender.Male, "Hà Nội" }, // invalid birth year
+      { 2000, Name.Gender.Male, "London" }, // invalid city
+   };
+
+   #endregion
+   
+   #region Tests
+   
+   [Fact]
+   public void can_generate_vietnamese_citizen_id()
+   {
+      // Arrange
+      var faker = new Faker("vi");
+      var person = faker.Person;
+      
+      // Act
+      var obtained = person.Cccd();
+      obtained.Dump();
+      
+      // Assert
+      obtained.Should().NotBeNullOrWhiteSpace();
+      ShouldBeLegalVietnameseCitizenId(obtained);
+      ShouldHaveCorrectInformationPart(obtained, faker.Person);
+   }
+   
+   [Theory]
+   [MemberData(nameof(ValidVietnameseCitizenIdTestCases))]
+   public void can_generate_vietnamese_citizen_id_with_valid_info(int birthYear, Name.Gender gender, string city)
+   {
+      // Arrange
+      var faker = new Faker();
+      var person = faker.Person;
+      person.DateOfBirth = new DateTime(birthYear, 1, 1);
+      person.Address.City = city;
+      person.Gender = gender;
+      
+      // Act
+      var obtained = person.Cccd();
+      obtained.Dump();
+      
+      // Assert
+      obtained.Should().NotBeNullOrWhiteSpace();
+      ShouldBeLegalVietnameseCitizenId(obtained);
+      ShouldHaveCorrectInformationPart(obtained, faker.Person);
+   }
+
+   [Theory]
+   [MemberData(nameof(InvalidVietnameseCitizenIdTestCases))]
+   public void cannot_generate_vietnamese_citizen_id_with_invalid_info(int birthYear, Name.Gender gender, string city)
+   {
+      // Arrange
+      var faker = new Faker();
+      var person = faker.Person;
+      person.DateOfBirth = new DateTime(birthYear, 1, 1);
+      person.Gender = gender;
+      person.Address.City = city;
+      
+      // Act
+      Action act = () => faker.Person.Cccd();
+      
+      // Assert
+      act.Should().Throw<ArgumentException>();
+   }
+
+   [Fact]
+   public void cannot_generate_vietnamese_citizen_id_without_vietnamese_locale()
+   {
+      // Arrange
+      var faker = new Faker("en");
+      
+      // Act
+      Action act = () => faker.Person.Cccd();
+      
+      // Assert
+      act.Should().Throw<ArgumentException>();
+   }
+
+   #endregion
+
+   #region Private methods
+   
+   private static void ShouldBeLegalVietnameseCitizenId(string candidate)
+   {
+      candidate.Should().NotBeNullOrWhiteSpace();
+      candidate.Should().MatchRegex(@"^\d{12}$");
+   }
+
+   private static void ShouldHaveCorrectInformationPart(string candidate, Person p)
+   {
+      var provinceCityCode = candidate.Substring(0, 3);
+      var genderCode = candidate.Substring(3, 1);
+      var birthYearCode = candidate.Substring(4, 2);
+      var randomNumber = int.Parse(candidate.Substring(6, 6));
+
+      provinceCityCode
+         .Should()
+         .BeEquivalentTo(VietnameseCityCodes.CityCodes[p.Address.City]);
+      genderCode
+         .Should()
+         .BeEquivalentTo(GetGenderCode(p.Gender, p.DateOfBirth.Year).ToString());
+      birthYearCode
+         .Should()
+         .BeEquivalentTo(p.DateOfBirth.Year.ToString().Substring(2));
+      randomNumber
+         .Should()
+         .BeInRange(1, 999999);
+   }
+   
+   private static int GetGenderCode(Name.Gender gender, int year)
+   {
+      return year switch
+      {
+         >= 1900 and <= 1999 => (int)gender,
+         >= 2000 and <= 2099 => (int)gender + 2,
+         >= 2100 and <= 2199 => (int)gender + 4,
+         _ => throw new ArgumentException($"Year of birth {year} is not supported.")
+      };
+   }
+   
+   #endregion
+}

--- a/Source/Bogus/Extensions/Vietnam/ExtensionsForVietnam.cs
+++ b/Source/Bogus/Extensions/Vietnam/ExtensionsForVietnam.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Bogus.Extensions.Vietnam;
+
+/// <summary>
+/// API extensions specific for a geographical location.
+/// </summary>
+public static class ExtensionsForVietnam
+{
+   /// <summary>
+   /// The Citizen Identity Card Number (Căn Cước Công Dân - CCCD)
+   /// is a unique 12-digit number registered to each Vietnamese citizen.
+   /// </summary>
+   /// <param name="p">The citizen owning the Citizen Identity Card Number</param>
+   /// <returns>The generated Citizen Identity Card Number</returns>
+   /// <exception cref="ArgumentException">Thrown when the city or year of birth is not supported.</exception>
+   /// <seealso href="https://vi.wikipedia.org/wiki/C%C4%83n_c%C6%B0%E1%BB%9Bc_c%C3%B4ng_d%C3%A2n_(Vi%E1%BB%87t_Nam)"/>
+   public static string Cccd(this Person p)
+   {
+      /*
+         https://vi.wikipedia.org/wiki/C%C4%83n_c%C6%B0%E1%BB%9Bc_c%C3%B4ng_d%C3%A2n_(Vi%E1%BB%87t_Nam)
+         CCC.G.BB.RRRRRR
+         |   | |  |
+         |   | |  |
+         |   | |  |------> (R) Random number from 000001 to 999999.
+         |   | |---------> (B) Birth year code of the citizen (last two digits of the birth year).
+         |   |-----------> (G) Gender code based on the century of birth (20th century: Male 0, Female 1; 21st century: Male 2, Female 3; ...).
+         |---------------> (C) Code of the province, city where the citizen is registered at birth.
+      */
+
+      const string key = nameof(ExtensionsForVietnam) + nameof(Cccd);
+      if (p.context.TryGetValue(key, out var cccdNumber) )
+      {
+         return cccdNumber as string;
+      }
+
+      var randomNumber = p.Random.Number(1, 999999).ToString("D6");
+
+      var birthYearCode = p.DateOfBirth.Year.ToString().Substring(2);
+
+      var genderCode = p.DateOfBirth.Year switch
+      {
+         (>= 1900 and <= 1999) => (int)p.Gender,          // 20th Century: Male = 0, Female = 1
+         (>= 2000 and <= 2099) => (int)p.Gender + 2,      // 21st Century: Male = 2, Female = 3
+         (>= 2100 and <= 2199) => (int)p.Gender + 4,      // 22nd Century: Male = 4, Female = 5
+         _ => throw new ArgumentException($"Year of birth {p.DateOfBirth.Year} is not supported.")
+      };
+
+      if (!VietnameseCityCodes.CityCodes.TryGetValue(p.Address.City, out var provinceCityCode))
+      { 
+         throw new ArgumentException($"City {p.Address.City} is not supported.");
+      }
+
+      var generatedNumber = $"{provinceCityCode}{genderCode}{birthYearCode}{randomNumber}";
+      p.context[key] = generatedNumber;
+      return generatedNumber;
+   }
+}

--- a/Source/Bogus/Extensions/Vietnam/VietnameseCityCodes.cs
+++ b/Source/Bogus/Extensions/Vietnam/VietnameseCityCodes.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+
+namespace Bogus.Extensions.Vietnam;
+
+public static class VietnameseCityCodes
+{
+   /// <summary>
+   /// The dictionary containing the city names and their corresponding city codes
+   /// used for generating Vietnamese Citizen Identity Card Number (Căn Cước Công Dân - CCCD).
+   /// </summary>
+   /// <seealso href="https://vi.wikipedia.org/wiki/C%C4%83n_c%C6%B0%E1%BB%9Bc_c%C3%B4ng_d%C3%A2n_(Vi%E1%BB%87t_Nam)"/>
+   public static readonly IDictionary<string, string> CityCodes = new Dictionary<string, string>
+   {
+      { "Hà Nội", "001" },
+      { "Hà Giang", "002" },
+      { "Cao Bằng", "004" },
+      { "Bắc Kạn", "006" },
+      { "Tuyên Quang", "008" },
+      { "Lào Cai", "010" },
+      { "Điện Biên", "011" },
+      { "Lai Châu", "012" },
+      { "Sơn La", "014" },
+      { "Yên Bái", "015" },
+      { "Hòa Bình", "017" },
+      { "Thái Nguyên", "019" },
+      { "Lạng Sơn", "020" },
+      { "Quảng Ninh", "022" },
+      { "Bắc Giang", "024" },
+      { "Phú Thọ", "025" },
+      { "Vĩnh Phúc", "026" },
+      { "Bắc Ninh", "027" },
+      { "Hải Dương", "030" },
+      { "Hải Phòng", "031" },
+      { "Hưng Yên", "033" },
+      { "Thái Bình", "034" },
+      { "Hà Nam", "035" },
+      { "Nam Định", "036" },
+      { "Ninh Bình", "037" },
+      { "Thanh Hóa", "038" },
+      { "Nghệ An", "040" },
+      { "Hà Tĩnh", "042" },
+      { "Quảng Bình", "044" },
+      { "Quảng Trị", "045" },
+      { "Thừa Thiên Huế", "046" },
+      { "Đà Nẵng", "048" },
+      { "Quảng Nam", "049" },
+      { "Quảng Ngãi", "051" },
+      { "Bình Định", "052" },
+      { "Phú Yên", "054" },
+      { "Khánh Hòa", "056" },
+      { "Ninh Thuận", "058" },
+      { "Bình Thuận", "060" },
+      { "Kon Tum", "062" },
+      { "Gia Lai", "064" },
+      { "Đắk Lắk", "066" },
+      { "Đắk Nông", "067" },
+      { "Lâm Đồng", "068" },
+      { "Bình Phước", "070" },
+      { "Tây Ninh", "072" },
+      { "Bình Dương", "074" },
+      { "Đồng Nai", "075" },
+      { "Bà Rịa-Vũng Tàu", "077" },
+      { "TP. Hồ Chí Minh", "079" },
+      { "Long An", "080" },
+      { "Tiền Giang", "082" },
+      { "Bến Tre", "083" },
+      { "Trà Vinh", "084" },
+      { "Vĩnh Long", "086" },
+      { "Đồng Tháp", "087" },
+      { "An Giang", "089" },
+      { "Kiên Giang", "091" },
+      { "Cần Thơ", "092" },
+      { "Hậu Giang", "093" },
+      { "Sóc Trăng", "094" },
+      { "Bạc Liêu", "095" },
+      { "Cà Mau", "096" }
+   };
+}


### PR DESCRIPTION
Hello, this PR added extension method to generate Vietnamese 12-digit Citizen Identity Card Number (_"Căn cước công dân - CCCD"_ in local language):
- Add extension method `Cccd()` on `Person` object in `Bogus.Extensions.Vietnam` namespace.
- Add unit tests.
- Modify `README.md`.