### PR TITLE
Fix for Randomizer.ULong() arithmetic overflow.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## v35.6.2
 Release Date: 2025-02-20
 * PR 584: Pack LICENSE file with NuGet package. Also, use ProjectIcon.
+* Issue 581: Fix `Randomizer.ULong()` arithmetic overflow.
 
 ## v35.6.1
 Release Date: 2024-09-02

--- a/Source/Bogus.Tests/GitHubIssues/Issue581.cs
+++ b/Source/Bogus.Tests/GitHubIssues/Issue581.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Bogus.Tests.GitHubIssues
+{
+    public class Issue581
+    {
+       [Fact]
+       public void overflow_test()
+       {
+          var randomizer = new Randomizer();
+          ulong max = ulong.MaxValue;
+          ulong min = max - 10;
+
+          ulong result = randomizer.ULong(min, max);
+
+          result.Should().BeInRange(min, max);
+       }
+   }
+}

--- a/Source/Bogus/Randomizer.cs
+++ b/Source/Bogus/Randomizer.cs
@@ -271,7 +271,7 @@ public class Randomizer
    /// <param name="max">Max value, inclusive. Default ulong.MaxValue</param>
    public ulong ULong(ulong min = ulong.MinValue, ulong max = ulong.MaxValue)
    {
-      return Convert.ToUInt64(Double() * (max - min) + min);
+      return Convert.ToUInt64(Double() * (max - min)) + min;
    }
 
    /// <summary>


### PR DESCRIPTION
Fixes #581 