### PR TITLE
Update Builder/Nuke to use .NET 9 SDK tooling and runtime.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "nuke.globaltool": {
-      "version": "6.3.0",
+      "version": "9.0.3",
       "commands": [
         "nuke"
       ]

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,15 +1,52 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/build",
-  "title": "Build Schema",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "BuildInfo",
+        "CI",
+        "Clean",
+        "Compile",
+        "Pack",
+        "Restore",
+        "SetupSnk",
+        "Test",
+        "Zip"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "BogusSnkZipPassword": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -19,25 +56,8 @@
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
@@ -66,53 +86,38 @@
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "BuildInfo",
-              "CI",
-              "Clean",
-              "Compile",
-              "Pack",
-              "Restore",
-              "SetupSnk",
-              "Test",
-              "Zip"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
-        },
-        "Solution": {
-          "type": "string",
-          "description": "Path to a solution file that is automatically loaded"
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "BuildInfo",
-              "CI",
-              "Clean",
-              "Compile",
-              "Pack",
-              "Restore",
-              "SetupSnk",
-              "Test",
-              "Zip"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
         "Verbosity": {
-          "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
+          "$ref": "#/definitions/Verbosity"
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "BogusSnkZipPassword": {
+          "type": "string",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
 }

--- a/Source/Bogus.Tests/Bogus.Tests.csproj
+++ b/Source/Bogus.Tests/Bogus.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-      <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>net472;net6.0;net9.0</TargetFrameworks>
    </PropertyGroup>
 
    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-      <TargetFrameworks>net8.0</TargetFrameworks>
+      <TargetFrameworks>net9.0</TargetFrameworks>
    </PropertyGroup>
    
   <PropertyGroup>

--- a/Source/Builder/Build.cs
+++ b/Source/Builder/Build.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using Z.ExtensionMethods;
 
 using static Nuke.Common.EnvironmentInfo;
+using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.IO.CompressionTasks;
@@ -96,7 +97,7 @@ partial class Build : NukeBuild
          .EnableNoRestore()
          );
 
-       CopyDirectoryRecursively(this.BogusProject.BinFolder(), this.BogusProject.CompileOutput());
+       this.BogusProject.BinFolder().Copy(this.BogusProject.CompileOutput());
 
     });
 

--- a/Source/Builder/Builder.csproj
+++ b/Source/Builder/Builder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;NU1701</NoWarn>
     <NukeRootDirectory>..\..</NukeRootDirectory>
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="Fake.DotNet.AssemblyInfoFile" Version="6.0.0" />
-    <PackageReference Include="Nuke.Common" Version="7.0.6" />
+    <PackageReference Include="Nuke.Common" Version="9.0.3" />
     <PackageReference Include="Z.ExtensionMethods.WithTwoNamespace" Version="2.0.13" />
   </ItemGroup>
 

--- a/Source/Builder/Utils.cs
+++ b/Source/Builder/Utils.cs
@@ -99,17 +99,17 @@ partial class Build
 
 public static class ExtensionMethodsForProject
 {
-   public static string BinFolder(this Project p)
+   public static AbsolutePath BinFolder(this Project p)
    {
       var result = p.Directory / "bin";
       return result;
    }
-   public static string CompileOutput(this Project p)
+   public static AbsolutePath CompileOutput(this Project p)
    {
       var result = Build.Folders.CompileOutput / p.Name;
       return result;
    }
-   public static string ZipFile(this Project p)
+   public static AbsolutePath ZipFile(this Project p)
    {
       var result = $"{p.Name}.zip";
       return result;


### PR DESCRIPTION
Additional changes required for Builder / NUKE to build in .NET 9 on Linux. Follow up PR for #586 