### PR TITLE
chore: Set PackageLicenseExpression property to MIT

### DIFF
--- a/Source/Bogus/Bogus.csproj
+++ b/Source/Bogus/Bogus.csproj
@@ -16,7 +16,7 @@
     <PackageIcon>bogus.128.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/bchavez/Bogus/master/Docs/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/bchavez/Bogus</PackageProjectUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/bchavez/Bogus</RepositoryUrl>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
## What does this PR do?
Switches from using the license file to indicate the license in the nuget package to using PackageLicenseExpression to explicitly define the license for the nugets.

## Why is it important?

This allows
- Allows tools like nuget-license (https://github.com/sensslen/nuget-license) to automatically detect the license of a package - currently we need to configure manual overrides and update the version in the override each time testconatainers gets updated
- nuget.org to show the license in the sidebar directly like this (see here: https://www.nuget.org/packages/dotnet-ef)
![grafik](https://github.com/user-attachments/assets/679e1f0b-eafb-449f-9377-bb7b72f2ff5e)

## How to test this PR
Manual test:
- Run `nuget pack` for any project in the repo
- Start manual upload process for a nuget here: https://www.nuget.org/packages/manage/upload
- The page will show the package metadata with license information for verification before finishing the upload

