### PR TITLE
Added Australian registration

### DIFF
--- a/Source/Bogus.Tests/ExtensionTests/AustraliaExtensionTests.cs
+++ b/Source/Bogus.Tests/ExtensionTests/AustraliaExtensionTests.cs
@@ -12,24 +12,24 @@ namespace Bogus.Tests.ExtensionTests
       public static IEnumerable<object[]> PlateFormatTestData()
       {
          // Each tuple: state, year, expected format regex
-         yield return ["ACT", 1970, @"^[Y][A-Z]{2}-\d{3}$"];
-         yield return ["ACT", 2000, @"^[Y][A-Z]{2}-\d{3}$"];
-         yield return ["NSW", 1955, @"^[A-Z]{3}-\d{3}$"];
-         yield return ["NSW", 2010, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];
-         yield return ["NT", 2000, @"^\d{3}-\d{3}$"];
-         yield return ["NT", 2015, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];
-         yield return ["QLD", 1960, @"^\d{3}-[A-Z]{3}$"];
-         yield return ["QLD", 2010, @"^[A-Z]{3}-\d{3}$"];
-         yield return ["QLD", 2022, @"^000-[A-Z][A-Z]\d$"];
-         yield return ["SA", 1970, @"^S\d{3}-[A-Z]{3}$"];
-         yield return ["SA", 2015, @"^S\d{3}-[A-Z]{3}$"];
-         yield return ["TAS", 1960, @"^[A-Z]{3}-\d{3}$"];
-         yield return ["TAS", 1970, @"^[A-Z]{2}-\d{4}$"];
-         yield return ["TAS", 2015, @"^M \d{2} [A-Z]{2}$"];
-         yield return ["VIC", 1960, @"^[A-Z]{3}-\d{3}$"];
-         yield return ["VIC", 2015, @"^\d[A-Z]{2}-[A-Z]{2}\d$"];
-         yield return ["WA", 1960, @"^[A-Z]{3}-\d{3}$"];
-         yield return ["WA", 2015, @"^\d[A-Z]{3}-\d{3}$"];
+         yield return ["ACT", 1970, @"^Y[A-Z]{2}-\d{3}$"];        
+         yield return ["ACT", 2000, @"^Y[A-Z]{2}-\d{3}$"];         
+         yield return ["NSW", 1955, @"^[A-Z]{3}-\d{3}$"];          
+         yield return ["NSW", 2010, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"]; 
+         yield return ["NT", 2000, @"^\d{3}-\d{3}$"];              
+         yield return ["NT", 2015, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];  
+         yield return ["QLD", 1960, @"^\d{3}-[A-Z]{3}$"];          
+         yield return ["QLD", 2010, @"^[A-Z]{3}-\d{3}$"];          
+         yield return ["QLD", 2022, "^[01]{3}-[0-9][A-Z][0-9]$"];          
+         yield return ["SA", 1970, @"^S\d{3}-[A-Z]{3}$"];          
+         yield return ["SA", 2015, @"^S\d{3}-[A-Z]{3}$"];          
+         yield return ["TAS", 1960, @"^[A-Z]{3}-\d{3}$"];          
+         yield return ["TAS", 1970, @"^[A-Z]{3}-[0-9]{3}$"];          
+         yield return ["TAS", 2015, @"^M \d{2} [A-Z]{2}$"];        
+         yield return ["VIC", 1960, @"^[A-Z]{3}-\d{3}$"];          
+         yield return ["VIC", 2015, @"^\d[A-Z]{2}-\d[A-Z]{2}$"];   
+         yield return ["WA", 1960, @"^[A-Z]{3}-\d{3}$"];           
+         yield return ["WA", 2015, @"^\d[A-Z]{3}-\d{3}$"];       
       }
 
       [Theory]

--- a/Source/Bogus.Tests/ExtensionTests/AustraliaExtensionTests.cs
+++ b/Source/Bogus.Tests/ExtensionTests/AustraliaExtensionTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using Bogus.DataSets;
+using Bogus.Extensions.Australia;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bogus.Tests.ExtensionTests
+{
+   public class AustraliaExtensionTests(ITestOutputHelper console) : SeededTest
+   {
+      public static IEnumerable<object[]> PlateFormatTestData()
+      {
+         // Each tuple: state, year, expected format regex
+         yield return ["ACT", 1970, @"^[Y][A-Z]{2}-\d{3}$"];
+         yield return ["ACT", 2000, @"^[Y][A-Z]{2}-\d{3}$"];
+         yield return ["NSW", 1955, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["NSW", 2010, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];
+         yield return ["NT", 2000, @"^\d{3}-\d{3}$"];
+         yield return ["NT", 2015, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];
+         yield return ["QLD", 1960, @"^\d{3}-[A-Z]{3}$"];
+         yield return ["QLD", 2010, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["QLD", 2022, @"^000-[A-Z][A-Z]\d$"];
+         yield return ["SA", 1970, @"^S\d{3}-[A-Z]{3}$"];
+         yield return ["SA", 2015, @"^S\d{3}-[A-Z]{3}$"];
+         yield return ["TAS", 1960, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["TAS", 1970, @"^[A-Z]{2}-\d{4}$"];
+         yield return ["TAS", 2015, @"^M \d{2} [A-Z]{2}$"];
+         yield return ["VIC", 1960, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["VIC", 2015, @"^\d[A-Z]{2}-[A-Z]{2}\d$"];
+         yield return ["WA", 1960, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["WA", 2015, @"^\d[A-Z]{3}-\d{3}$"];
+      }
+
+      [Theory]
+      [MemberData(nameof(PlateFormatTestData))]
+      public void Generates_Correct_Plate_Format_For_State_And_Year(string state, int year, string expectedRegex)
+      {
+         var vehicle = new Vehicle();
+         var from = new DateTime(year, 1, 1);
+         var to = new DateTime(year, 12, 31);
+         var plate = vehicle.AusCarRegistrationPlate(from, to, state);
+         console.WriteLine($"{state} {year}: {plate}");
+         Assert.Matches(expectedRegex, plate);
+      }
+   }
+}

--- a/Source/Bogus.Tests/ExtensionTests/AustraliaExtensionTests.cs
+++ b/Source/Bogus.Tests/ExtensionTests/AustraliaExtensionTests.cs
@@ -2,34 +2,35 @@
 using System.Collections.Generic;
 using Bogus.DataSets;
 using Bogus.Extensions.Australia;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Bogus.Tests.ExtensionTests
 {
-   public class AustraliaExtensionTests(ITestOutputHelper console) : SeededTest
+   public class AustraliaExtensionTests(ITestOutputHelper console)
    {
       public static IEnumerable<object[]> PlateFormatTestData()
       {
          // Each tuple: state, year, expected format regex
-         yield return ["ACT", 1970, @"^Y[A-Z]{2}-\d{3}$"];        
-         yield return ["ACT", 2000, @"^Y[A-Z]{2}-\d{3}$"];         
-         yield return ["NSW", 1955, @"^[A-Z]{3}-\d{3}$"];          
-         yield return ["NSW", 2010, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"]; 
-         yield return ["NT", 2000, @"^\d{3}-\d{3}$"];              
-         yield return ["NT", 2015, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];  
-         yield return ["QLD", 1960, @"^\d{3}-[A-Z]{3}$"];          
-         yield return ["QLD", 2010, @"^[A-Z]{3}-\d{3}$"];          
-         yield return ["QLD", 2022, "^[01]{3}-[0-9][A-Z][0-9]$"];          
-         yield return ["SA", 1970, @"^S\d{3}-[A-Z]{3}$"];          
-         yield return ["SA", 2015, @"^S\d{3}-[A-Z]{3}$"];          
-         yield return ["TAS", 1960, @"^[A-Z]{3}-\d{3}$"];          
-         yield return ["TAS", 1970, @"^[A-Z]{3}-[0-9]{3}$"];          
-         yield return ["TAS", 2015, @"^M \d{2} [A-Z]{2}$"];        
-         yield return ["VIC", 1960, @"^[A-Z]{3}-\d{3}$"];          
-         yield return ["VIC", 2015, @"^\d[A-Z]{2}-\d[A-Z]{2}$"];   
-         yield return ["WA", 1960, @"^[A-Z]{3}-\d{3}$"];           
-         yield return ["WA", 2015, @"^\d[A-Z]{3}-\d{3}$"];       
+         yield return ["ACT", 1970, @"^Y[A-Z]{2}-\d{3}$"];
+         yield return ["ACT", 2000, @"^Y[A-Z]{2}-\d{3}$"];
+         yield return ["NSW", 1955, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["NSW", 2010, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];
+         yield return ["NT", 2000, @"^\d{3}-\d{3}$"];
+         yield return ["NT", 2015, @"^[A-Z]{2}-\d{2}-[A-Z]{2}$"];
+         yield return ["QLD", 1960, @"^\d{3}-[A-Z]{3}$"];
+         yield return ["QLD", 2010, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["QLD", 2022, "^[01]{3}-[0-9][A-Z][0-9]$"];
+         yield return ["SA", 1970, @"^S\d{3}-[A-Z]{3}$"];
+         yield return ["SA", 2015, @"^S\d{3}-[A-Z]{3}$"];
+         yield return ["TAS", 1960, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["TAS", 1970, @"^[A-Z]{3}-[0-9]{3}$"];
+         yield return ["TAS", 2015, @"^M \d{2} [A-Z]{2}$"];
+         yield return ["VIC", 1960, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["VIC", 2015, @"^\d[A-Z]{2}-\d[A-Z]{2}$"];
+         yield return ["WA", 1960, @"^[A-Z]{3}-\d{3}$"];
+         yield return ["WA", 2015, @"^\d[A-Z]{3}-\d{3}$"];
       }
 
       [Theory]
@@ -42,6 +43,18 @@ namespace Bogus.Tests.ExtensionTests
          var plate = vehicle.AusCarRegistrationPlate(from, to, state);
          console.WriteLine($"{state} {year}: {plate}");
          Assert.Matches(expectedRegex, plate);
+      }
+
+      [Fact]
+      public void Generates_Correct_Plate_Format_For_Random_State()
+      {
+         var vehicle = new Vehicle();
+         var currentYear = DateTime.Now.Year;
+         var from = new DateTime(currentYear, 1, 1);
+         var to = new DateTime(currentYear, 12, 31);
+         var plate = vehicle.AusCarRegistrationPlate(from, to);
+         console.WriteLine($"Random State {currentYear}: {plate}");
+         plate.Should().NotBe(null).And.NotBe(string.Empty);
       }
    }
 }

--- a/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
+++ b/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
@@ -33,9 +33,10 @@ public static class ExtensionsForAustraliaRegistrationPlate
    /// Different vehicle types also have different registration plate formats.
    /// Currently, this method only supports the "Car" or universal type of vehicle registration plates. 
    /// </remarks>
-   public static string AusCarRegistrationPlate(this Vehicle vehicle, DateTime from, DateTime to, string state)
+   public static string AusCarRegistrationPlate(this Vehicle vehicle, DateTime from, DateTime to, string state = null)
    {
-      if (! SupportedStates.Contains(state)) 
+      state ??= GenerateRandomState();
+      if (!SupportedStates.Contains(state))
          throw new ArgumentException($"Unsupported Australian state: {state}. Supported states are: {string.Join(", ", SupportedStates)}", nameof(state));
       DateTime registrationDate = GenerateRegistrationDate(vehicle, from, to);
       return GenerateRegistrationPlate(vehicle, registrationDate, state);
@@ -164,5 +165,11 @@ public static class ExtensionsForAustraliaRegistrationPlate
          }
       }
       return sb.ToString();
+   }
+
+   private static string GenerateRandomState()
+   {
+      var randomizer = new Randomizer();
+      return randomizer.ListItem(SupportedStates.ToList());
    }
 }

--- a/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
+++ b/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
@@ -11,13 +11,19 @@ namespace Bogus.Extensions.Australia;
 /// </summary>
 public static class ExtensionsForAustraliaRegistrationPlate
 {
+
+   /// <summary>
+   /// HashSet of supported Australian states.
+   /// </summary>
+   private static readonly HashSet<string> SupportedStates = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "NT", "ACT"];
+
    /// <summary>
    /// Australian Vehicle Registration Plates
    /// </summary>
    /// <param name="vehicle"></param>
    /// <param name="from">The start of the range of registration dates.</param>
    /// <param name="to">The end of the range of registration dates.</param>
-   /// <param name="state">The state for which the registration plate is to be generated.</param>
+   /// <param name="state">The state abbreviation for which the registration plate is to be generated.</param>
    /// <returns></returns>
    /// <remarks>
    /// This is based on the information in the Wikipedia article on
@@ -29,12 +35,18 @@ public static class ExtensionsForAustraliaRegistrationPlate
    /// </remarks>
    public static string AusCarRegistrationPlate(this Vehicle vehicle, DateTime from, DateTime to, string state)
    {
+      if (! SupportedStates.Contains(state)) 
+         throw new ArgumentException($"Unsupported Australian state: {state}. Supported states are: {string.Join(", ", SupportedStates)}", nameof(state));
       DateTime registrationDate = GenerateRegistrationDate(vehicle, from, to);
       return GenerateRegistrationPlate(vehicle, registrationDate, state);
    }
 
-   private static readonly HashSet<string> SupportedStates = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "NT", "ACT"];
-
+   /// <summary>
+   /// Represents a rule for formatting vehicle license plates based on a specified year range.
+   /// </summary>
+   /// <remarks>This class defines the format and logic for generating license plate numbers for vehicles
+   /// registered within a specific range of years. The <see cref="Generator"/> property can be used to provide custom
+   /// logic for generating the plate format.</remarks>
    private class PlateFormatRule
    {
       public int StartYear { get; set; }
@@ -68,7 +80,7 @@ public static class ExtensionsForAustraliaRegistrationPlate
       [
          new PlateFormatRule { StartYear = 1955, EndYear = 1977, Format = "NNN-LLL" },
          new PlateFormatRule { StartYear = 1978, EndYear = 2019, Format = "LLL-NNN" },
-         new PlateFormatRule { StartYear = 2020, EndYear = 9999, Format = "NNN-NLN" }
+         new PlateFormatRule { StartYear = 2020, EndYear = 9999, Format = "000-NLN" }
       ],
       ["SA"] =
       [
@@ -77,21 +89,32 @@ public static class ExtensionsForAustraliaRegistrationPlate
       ],
       ["TAS"] =
       [
-         new PlateFormatRule { StartYear = 1954, EndYear = 1970, Format = "LLL-NNL" },
-         new PlateFormatRule { StartYear = 1971, EndYear = 9999, Format = "MNN-AA" }
+         new PlateFormatRule { StartYear = 1954, EndYear = 1970, Format = "LLL-NNN" },
+         new PlateFormatRule { StartYear = 1970, EndYear = 1971, Format = "LL-NNNN" },
+         new PlateFormatRule { StartYear = 1971, EndYear = 9999, Format = "M NN LL" }
       ],
       ["VIC"] =
       [
+         new PlateFormatRule { StartYear = 1910, EndYear = 1939, Format = "NNN-NNN" },
+         new PlateFormatRule { StartYear = 1939, EndYear = 1953, Format = "LL-NNN" },
          new PlateFormatRule { StartYear = 1953, EndYear = 2013, Format = "LLL-NNN" },
-         new PlateFormatRule { StartYear = 2014, EndYear = 9999, Format = "NLL-NNL" }
+         new PlateFormatRule { StartYear = 2014, EndYear = 9999, Format = "NLL-NLL" }
       ],
       ["WA"] =
       [
-         new PlateFormatRule { StartYear = 1956, EndYear = 1978, Format = "NLLL-NNN" },
-         new PlateFormatRule { StartYear = 1979, EndYear = 9999, Format = "NLL-NNN" }
+         new PlateFormatRule { StartYear = 1956, EndYear = 1978, Format = "LLL-NNN" },
+         new PlateFormatRule { StartYear = 1979, EndYear = 9999, Format = "NLLL-NNN" }
       ]
    };
 
+
+   /// <summary>
+   /// This method generates a random registration date for a vehicle within a specified date range.
+   /// </summary>
+   /// <param name="vehicle"></param>
+   /// <param name="from"></param>
+   /// <param name="to"></param>
+   /// <returns></returns>
    private static DateTime GenerateRegistrationDate(Vehicle vehicle, DateTime from, DateTime to)
    {
       // Swap if needed
@@ -133,6 +156,7 @@ public static class ExtensionsForAustraliaRegistrationPlate
          {
             case 'L': sb.Append(vehicle.Random.ArrayElement(Letters)); break;
             case 'N': sb.Append(vehicle.Random.ArrayElement(Digits)); break;
+            case '0': sb.Append(vehicle.Random.Digits(1, 0, 1)); break;
             case 'M': sb.Append('M'); break;
             case 'S': sb.Append('S'); break;
             case 'Y': sb.Append('Y'); break;

--- a/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
+++ b/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
@@ -59,15 +59,14 @@ public static class ExtensionsForAustraliaRegistrationPlate
    {
       ["ACT"] =
       [
-         new PlateFormatRule { StartYear = 1911, EndYear = 1998, Format = "NN-NNN" },
-         new PlateFormatRule { StartYear = 1968, EndYear = 1998, Format = "YLL-NNN" },
+         new PlateFormatRule { StartYear = 1911, EndYear = 1968, Format = "NN-NNN" },
+         new PlateFormatRule { StartYear = 1969, EndYear = 1998, Format = "YLL-NNN" },
          new PlateFormatRule { StartYear = 1999, EndYear = 9999, Format = "YLL-NNN" }
       ],
       ["NSW"] =
       [
          new PlateFormatRule { StartYear = 1910, EndYear = 1937, Format = "NNN-NNN" },
-         new PlateFormatRule { StartYear = 1924, EndYear = 1937, Format = "NNN-NNN" },
-         new PlateFormatRule { StartYear = 1937, EndYear = 1951, Format = "LL-NNN" },
+         new PlateFormatRule { StartYear = 1938, EndYear = 1951, Format = "LL-NNN" },
          new PlateFormatRule { StartYear = 1951, EndYear = 2004, Format = "LLL-NNN" },
          new PlateFormatRule { StartYear = 2005, EndYear = 9999, Format = "LL-NN-LL" }
       ],
@@ -90,14 +89,14 @@ public static class ExtensionsForAustraliaRegistrationPlate
       ["TAS"] =
       [
          new PlateFormatRule { StartYear = 1954, EndYear = 1970, Format = "LLL-NNN" },
-         new PlateFormatRule { StartYear = 1970, EndYear = 1971, Format = "LL-NNNN" },
-         new PlateFormatRule { StartYear = 1971, EndYear = 9999, Format = "M NN LL" }
+         new PlateFormatRule { StartYear = 1971, EndYear = 1971, Format = "LL-NNNN" },
+         new PlateFormatRule { StartYear = 1972, EndYear = 9999, Format = "M NN LL" }
       ],
       ["VIC"] =
       [
          new PlateFormatRule { StartYear = 1910, EndYear = 1939, Format = "NNN-NNN" },
-         new PlateFormatRule { StartYear = 1939, EndYear = 1953, Format = "LL-NNN" },
-         new PlateFormatRule { StartYear = 1953, EndYear = 2013, Format = "LLL-NNN" },
+         new PlateFormatRule { StartYear = 1940, EndYear = 1953, Format = "LL-NNN" },
+         new PlateFormatRule { StartYear = 1954, EndYear = 2013, Format = "LLL-NNN" },
          new PlateFormatRule { StartYear = 2014, EndYear = 9999, Format = "NLL-NLL" }
       ],
       ["WA"] =
@@ -156,7 +155,7 @@ public static class ExtensionsForAustraliaRegistrationPlate
          {
             case 'L': sb.Append(vehicle.Random.ArrayElement(Letters)); break;
             case 'N': sb.Append(vehicle.Random.ArrayElement(Digits)); break;
-            case '0': sb.Append(vehicle.Random.Digits(1, 0, 1)); break;
+            case '0': sb.Append(vehicle.Random.Number(1)); break;
             case 'M': sb.Append('M'); break;
             case 'S': sb.Append('S'); break;
             case 'Y': sb.Append('Y'); break;

--- a/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
+++ b/Source/Bogus/Extensions/Australia/ExtensionsForAustraliaRegistrationPlate.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Bogus.DataSets;
+
+namespace Bogus.Extensions.Australia;
+
+/// <summary>
+/// API extensions specific for a geographical location.
+/// </summary>
+public static class ExtensionsForAustraliaRegistrationPlate
+{
+   /// <summary>
+   /// Australian Vehicle Registration Plates
+   /// </summary>
+   /// <param name="vehicle"></param>
+   /// <param name="from">The start of the range of registration dates.</param>
+   /// <param name="to">The end of the range of registration dates.</param>
+   /// <param name="state">The state for which the registration plate is to be generated.</param>
+   /// <returns></returns>
+   /// <remarks>
+   /// This is based on the information in the Wikipedia article on
+   /// Vehicle registration plates of Australia.
+   /// https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Australia
+   /// Due to each state having its own registration plate format, we also need to provide a State Property on the Vehicle object.
+   /// Different vehicle types also have different registration plate formats.
+   /// Currently, this method only supports the "Car" or universal type of vehicle registration plates. 
+   /// </remarks>
+   public static string AusCarRegistrationPlate(this Vehicle vehicle, DateTime from, DateTime to, string state)
+   {
+      DateTime registrationDate = GenerateRegistrationDate(vehicle, from, to);
+      return GenerateRegistrationPlate(vehicle, registrationDate, state);
+   }
+
+   private static readonly HashSet<string> SupportedStates = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "NT", "ACT"];
+
+   private class PlateFormatRule
+   {
+      public int StartYear { get; set; }
+      public int EndYear { get; set; }
+      public string Format { get; set; }
+      public Func<Vehicle, DateTime, string> Generator { get; set; } // Optional for custom logic
+   }
+
+   private static readonly Dictionary<string, List<PlateFormatRule>> StatePlateRules = new()
+   {
+      ["ACT"] =
+      [
+         new PlateFormatRule { StartYear = 1911, EndYear = 1998, Format = "NN-NNN" },
+         new PlateFormatRule { StartYear = 1968, EndYear = 1998, Format = "YLL-NNN" },
+         new PlateFormatRule { StartYear = 1999, EndYear = 9999, Format = "YLL-NNN" }
+      ],
+      ["NSW"] =
+      [
+         new PlateFormatRule { StartYear = 1910, EndYear = 1937, Format = "NNN-NNN" },
+         new PlateFormatRule { StartYear = 1924, EndYear = 1937, Format = "NNN-NNN" },
+         new PlateFormatRule { StartYear = 1937, EndYear = 1951, Format = "LL-NNN" },
+         new PlateFormatRule { StartYear = 1951, EndYear = 2004, Format = "LLL-NNN" },
+         new PlateFormatRule { StartYear = 2005, EndYear = 9999, Format = "LL-NN-LL" }
+      ],
+      ["NT"] =
+      [
+         new PlateFormatRule { StartYear = 1931, EndYear = 2011, Format = "NNN-NNN" },
+         new PlateFormatRule { StartYear = 2012, EndYear = 9999, Format = "LL-NN-AA" }
+      ],
+      ["QLD"] =
+      [
+         new PlateFormatRule { StartYear = 1955, EndYear = 1977, Format = "NNN-LLL" },
+         new PlateFormatRule { StartYear = 1978, EndYear = 2019, Format = "LLL-NNN" },
+         new PlateFormatRule { StartYear = 2020, EndYear = 9999, Format = "NNN-NLN" }
+      ],
+      ["SA"] =
+      [
+         new PlateFormatRule { StartYear = 1967, EndYear = 2008, Format = "SNNN-LLL" },
+         new PlateFormatRule { StartYear = 2009, EndYear = 9999, Format = "SNNN-LLL" }
+      ],
+      ["TAS"] =
+      [
+         new PlateFormatRule { StartYear = 1954, EndYear = 1970, Format = "LLL-NNL" },
+         new PlateFormatRule { StartYear = 1971, EndYear = 9999, Format = "MNN-AA" }
+      ],
+      ["VIC"] =
+      [
+         new PlateFormatRule { StartYear = 1953, EndYear = 2013, Format = "LLL-NNN" },
+         new PlateFormatRule { StartYear = 2014, EndYear = 9999, Format = "NLL-NNL" }
+      ],
+      ["WA"] =
+      [
+         new PlateFormatRule { StartYear = 1956, EndYear = 1978, Format = "NLLL-NNN" },
+         new PlateFormatRule { StartYear = 1979, EndYear = 9999, Format = "NLL-NNN" }
+      ]
+   };
+
+   private static DateTime GenerateRegistrationDate(Vehicle vehicle, DateTime from, DateTime to)
+   {
+      // Swap if needed
+      if (from > to)
+      {
+         var temp = from;
+         from = to;
+         to = temp;
+      }
+      from = from.Date;
+      to = to.Date;
+      int duration = (int)(to - from).TotalDays;
+      int offset = vehicle.Random.Int(0, duration);
+      return from.AddDays(offset);
+   }
+
+   private static string GenerateRegistrationPlate(Vehicle vehicle, DateTime registrationDate, string state)
+   {
+      state = state.ToUpperInvariant();
+      if (!StatePlateRules.ContainsKey(state))
+         throw new ArgumentException($"Unsupported Australian state: {state}", nameof(state));
+      int year = registrationDate.Year;
+      var rules = StatePlateRules[state];
+      var rule = rules.FirstOrDefault(r => year >= r.StartYear && year <= r.EndYear);
+      if (rule == null)
+         throw new ArgumentException($"No plate format for {state} in year {year}");
+      return rule.Generator != null ? rule.Generator(vehicle, registrationDate) : GeneratePlateFromFormat(vehicle, rule.Format);
+   }
+
+   private static readonly char[] Letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".ToCharArray();
+   private static readonly char[] Digits = "0123456789".ToCharArray();
+
+   private static string GeneratePlateFromFormat(Vehicle vehicle, string format)
+   {
+      var sb = new StringBuilder();
+      foreach (var c in format)
+      {
+         switch (c)
+         {
+            case 'L': sb.Append(vehicle.Random.ArrayElement(Letters)); break;
+            case 'N': sb.Append(vehicle.Random.ArrayElement(Digits)); break;
+            case 'M': sb.Append('M'); break;
+            case 'S': sb.Append('S'); break;
+            case 'Y': sb.Append('Y'); break;
+            case '-': sb.Append('-'); break;
+            default: sb.Append(c); break;
+         }
+      }
+      return sb.ToString();
+   }
+}


### PR DESCRIPTION
This pull request introduces a new feature to generate Australian vehicle registration plates with state-specific formats. It includes both the implementation of the feature and corresponding unit tests to ensure correctness. The most important changes are grouped into feature implementation and testing.

### Feature Implementation:

* Added a new extension method `AusCarRegistrationPlate` in `ExtensionsForAustraliaRegistrationPlate.cs` to generate Australian vehicle registration plates based on the state, year, and date range. This method validates the state, determines the registration date, and applies state-specific formatting rules.
* Defined `PlateFormatRule` and `StatePlateRules` to encapsulate the logic for state-specific plate formats based on year ranges, including support for custom generation logic.
* Implemented helper methods such as `GenerateRegistrationDate`, `GenerateRegistrationPlate`, and `GeneratePlateFromFormat` to handle random date generation, format selection, and plate string construction.

### Testing:

* Added a new test class `AustraliaExtensionTests` in `AustraliaExtensionTests.cs` containing unit tests to verify the correctness of the `AusCarRegistrationPlate` method for various states and year ranges.
* Included a parameterized test `Generates_Correct_Plate_Format_For_State_And_Year` to validate that the generated plate matches the expected format for a given state and year.
* Added a test `Generates_Correct_Plate_Format_For_Random_State` to ensure that the method works correctly when no specific state is provided, generating a valid plate for a random state.