### PR TITLE
Add extension method for generating Iranian national number

### DIFF
--- a/Source/Bogus.Tests/ExtensionTests/IranianExtensionTests.cs
+++ b/Source/Bogus.Tests/ExtensionTests/IranianExtensionTests.cs
@@ -7,7 +7,6 @@ namespace Bogus.Tests.ExtensionTests;
 
 public class IranianExtensionTests : SeededTest
 {
-
    [Fact]
    public void can_create_valid_iranian_national_number()
    {

--- a/Source/Bogus.Tests/ExtensionTests/IranianExtensionTests.cs
+++ b/Source/Bogus.Tests/ExtensionTests/IranianExtensionTests.cs
@@ -1,0 +1,71 @@
+﻿using Bogus.Extensions.Iran;
+using FluentAssertions;
+using System.Linq;
+using Xunit;
+
+namespace Bogus.Tests.ExtensionTests;
+
+public class IranianExtensionTests : SeededTest
+{
+
+   [Fact]
+   public void can_create_valid_iranian_national_number()
+   {
+      var faker = new Faker("fa");
+      var nationalNumber = faker.Person.IranianNationalNumber();
+
+      nationalNumber.Should().MatchRegex("^[0-9]{10}$");
+
+      ValidateIranianNationalNumber(nationalNumber).Should().BeTrue();
+   }
+
+   [Fact]
+   public void iranian_national_number_generated_twice_are_equal()
+   {
+      var faker = new Faker("fa");
+      var person = faker.Person;
+      var nationalNumber1 = person.IranianNationalNumber();
+      var nationalNumber2 = person.IranianNationalNumber();
+
+      nationalNumber1.Should().Be(nationalNumber2);
+   }
+
+   [Fact]
+   public void iranian_national_number_should_be_different_for_different_persons()
+   {
+      var faker1 = new Faker("fa");
+      var faker2 = new Faker("fa");
+      var person1 = faker1.Person;
+      var person2 = faker2.Person;
+
+      var nationalNumber1 = person1.IranianNationalNumber();
+      var nationalNumber2 = person2.IranianNationalNumber();
+
+      nationalNumber1.Should().NotBe(nationalNumber2);
+   }
+
+   /// <summary>
+   /// Validates an Iranian National Number using the official algorithm.
+   /// The checksum is calculated as: sum of (digit * position_weight) mod 11
+   /// where position_weight starts from 10 and decreases to 2.
+   /// The last digit should be the remainder, or 11 - remainder if remainder >= 2.
+   /// </summary>
+   private static bool ValidateIranianNationalNumber(string nationalNumber)
+   {
+      if (string.IsNullOrEmpty(nationalNumber) || nationalNumber.Length != 10 || !nationalNumber.All(char.IsDigit))
+         return false;
+
+      var digits = nationalNumber.Select(c => c - '0').ToArray();
+
+      var sum = 0;
+      for (int i = 0; i < 9; i++)
+      {
+         sum += digits[i] * (10 - i);
+      }
+
+      var remainder = sum % 11;
+      var expectedChecksum = remainder < 2 ? remainder : 11 - remainder;
+
+      return digits[9] == expectedChecksum;
+   }
+}

--- a/Source/Bogus.Tests/ExtensionTests/IranianExtensionTests.cs
+++ b/Source/Bogus.Tests/ExtensionTests/IranianExtensionTests.cs
@@ -10,36 +10,46 @@ public class IranianExtensionTests : SeededTest
    [Fact]
    public void can_create_valid_iranian_national_number()
    {
+      //Arrange 
       var faker = new Faker("fa");
+
+      //Act
       var nationalNumber = faker.Person.IranianNationalNumber();
 
+      //Assert
       nationalNumber.Should().MatchRegex("^[0-9]{10}$");
-
       ValidateIranianNationalNumber(nationalNumber).Should().BeTrue();
    }
 
    [Fact]
    public void iranian_national_number_generated_twice_are_equal()
    {
+      //Arrange
       var faker = new Faker("fa");
       var person = faker.Person;
+
+      //Act
       var nationalNumber1 = person.IranianNationalNumber();
       var nationalNumber2 = person.IranianNationalNumber();
 
+      //Assert
       nationalNumber1.Should().Be(nationalNumber2);
    }
 
    [Fact]
    public void iranian_national_number_should_be_different_for_different_persons()
    {
+      //Arrange
       var faker1 = new Faker("fa");
       var faker2 = new Faker("fa");
       var person1 = faker1.Person;
       var person2 = faker2.Person;
 
+      //Act
       var nationalNumber1 = person1.IranianNationalNumber();
       var nationalNumber2 = person2.IranianNationalNumber();
 
+      //Assert
       nationalNumber1.Should().NotBe(nationalNumber2);
    }
 

--- a/Source/Bogus/Extensions/Iran/ExtensionsForIran.cs
+++ b/Source/Bogus/Extensions/Iran/ExtensionsForIran.cs
@@ -32,6 +32,9 @@ public static class ExtensionsForIran
       int s = sum % 11;
       list[9] = s < 2 ? s : 11 - s;
 
-      return string.Join(string.Empty, list);
+      string result = string.Join(string.Empty, list);
+      p.context[Key] = result;
+
+      return result;
    }
 }

--- a/Source/Bogus/Extensions/Iran/ExtensionsForIran.cs
+++ b/Source/Bogus/Extensions/Iran/ExtensionsForIran.cs
@@ -1,0 +1,37 @@
+namespace Bogus.Extensions.Iran;
+
+/// <summary>
+/// API extensions specific for Iran.
+/// </summary>
+public static class ExtensionsForIran
+{
+   /// <summary>
+   /// Generates a fake Iranian National Number (کد ملی) with a valid checksum.
+   /// </summary>
+   /// <param name="p">The person for whom to generate the national number.</param>
+   /// <returns>A valid 10-digit Iranian national number as a string.</returns>
+   public static string IranianNationalNumber(this Person p)
+   {
+      const string Key = nameof(ExtensionsForIran) + nameof(IranianNationalNumber);
+      if (p.context.TryGetValue(Key, out var value))
+      {
+         return value as string;
+      }
+
+      Randomizer randomizer = p.Random;
+
+      int[] list = new int[10];
+      int sum = 0;
+
+      for (int i = 0; i < 9; i++)
+      {
+         list[i] = randomizer.Number(9);
+         sum += list[i] * (10 - i);
+      }
+
+      int s = sum % 11;
+      list[9] = s < 2 ? s : 11 - s;
+
+      return string.Join(string.Empty, list);
+   }
+}


### PR DESCRIPTION
This pull request introduces a new feature to generate Iranian national number. The unit tests are also included.

### Feature Implementation
- Added a new static class called `ExtensionsForIran` inside a new folder called `Iran` in the Extensions folder.
- Added a new extension method inside the `ExtensionsForIran` class called `IranianNationalNumber` to generate valid Iranian national number.
### Feature Testing
- Added a new class called `IranianExtensionTests` inside the ExtensionTests folder. This class contains four newly added methods described below 👇
1. `ValidateIranianNationalNumber` : This is responsible for validating any given national number via a specific algorithm and is used by other test methods.
2. `can_create_valid_iranian_national_number` : This will ensure the output matches the expected pattern and is actually a valid national number.
3. `iranian_national_number_generated_twice_are_equal` : This will ensure that national number remains the same for the `Person` object even if generated twice.
4. `iranian_national_number_should_be_different_for_different_persons` : This will ensure the national number of two different `Person` objects are not the same. 