### PR TITLE
fix incorrect as usages

### DIFF
--- a/Source/Bogus/Bson/Bson.cs
+++ b/Source/Bogus/Bson/Bson.cs
@@ -189,12 +189,12 @@ public class Bson
          case BValueType.Object:
             ms.WriteByte(0x03);
             EncodeCString(ms, name);
-            EncodeDocument(ms, v as BObject);
+            EncodeDocument(ms, (BObject)v);
             return;
          case BValueType.Array:
             ms.WriteByte(0x04);
             EncodeCString(ms, name);
-            EncodeArray(ms, v as BArray);
+            EncodeArray(ms, (BArray)v);
             return;
          case BValueType.Binary:
             ms.WriteByte(0x05);

--- a/Source/Bogus/DataSets/Finance.cs
+++ b/Source/Bogus/DataSets/Finance.cs
@@ -379,7 +379,7 @@ public class Finance : DataSet
       IBanFormat ibanFormat;
       if( countryCode is null )
       {
-         var formatEntry = this.Random.ArrayElement(arr) as BObject;
+         var formatEntry = (BObject)this.Random.ArrayElement(arr);
          ibanFormat = this.GetIbanFormat(formatEntry);
       }
       else
@@ -512,7 +512,7 @@ public class Finance : DataSet
 
    protected IBanFormat.BbanItem[] GetBbanItems(BObject obj)
    {
-      var arr = obj["bban"] as BArray;
+      var arr = (BArray)obj["bban"];
       return arr.OfType<BObject>()
          .Select(o => new IBanFormat.BbanItem
          {

--- a/Source/Bogus/DataSets/System.cs
+++ b/Source/Bogus/DataSets/System.cs
@@ -34,7 +34,7 @@ public class System : DataSet
             {
                if( bObject.ContainsKey("extensions") )
                {
-                  var extensions = bObject["extensions"] as BArray;
+                  var extensions = (BArray)bObject["extensions"];
                   return extensions.OfType<BValue>().Select(s => s.StringValue);
                }
                return Enumerable.Empty<string>();
@@ -197,7 +197,7 @@ public class System : DataSet
           lookup.TryGetValue(mimeType, out var mime) &&
           mime.ContainsKey("extensions") )
       {
-         return this.Random.ArrayElement(mime["extensions"] as BArray);
+         return this.Random.ArrayElement((BArray)mime["extensions"]);
       }
 
       return this.Random.ArrayElement(exts);

--- a/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
+++ b/Source/Bogus/Extensions/Brazil/ExtensionsForBrazil.cs
@@ -22,7 +22,7 @@ public static class ExtensionsForBrazil
       const string Key = nameof(ExtensionsForBrazil) + "CPF";
       if( p.context.TryGetValue(Key, out var value) )
       {
-         finalDigits = value as int[];
+         finalDigits = (int[])value;
          return FormatCpf(finalDigits, includeFormatSymbols);
       }
 

--- a/Source/Bogus/Extensions/Canada/ExtensionsForCanada.cs
+++ b/Source/Bogus/Extensions/Canada/ExtensionsForCanada.cs
@@ -17,7 +17,7 @@ public static class ExtensionsForCanada
       const string Key = nameof(ExtensionsForCanada) + "SIN";
       if( p.context.TryGetValue(Key, out var value) )
       {
-         return value as string;
+         return (string)value;
       }
 
       //bit verbose, but works. :)

--- a/Source/Bogus/Extensions/Denmark/ExtensionsForDenmark.cs
+++ b/Source/Bogus/Extensions/Denmark/ExtensionsForDenmark.cs
@@ -20,7 +20,7 @@ public static class ExtensionsForDenmark
       const string Key = nameof(ExtensionsForDenmark) + "CPR";
       if (p.context.TryGetValue(Key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       /*

--- a/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
+++ b/Source/Bogus/Extensions/Finland/ExtensionsForFinland.cs
@@ -15,7 +15,7 @@ public static class ExtensionsForFinland
       const string Key = nameof(ExtensionsForFinland) + "Henkilötunnus";
       if( p.context.TryGetValue(Key, out var value) )
       {
-         return value as string;
+         return (string)value;
       }
 
       // DDMMYYCZZZQ

--- a/Source/Bogus/Extensions/Iran/ExtensionsForIran.cs
+++ b/Source/Bogus/Extensions/Iran/ExtensionsForIran.cs
@@ -15,7 +15,7 @@ public static class ExtensionsForIran
       const string Key = nameof(ExtensionsForIran) + nameof(IranianNationalNumber);
       if (p.context.TryGetValue(Key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       Randomizer randomizer = p.Random;

--- a/Source/Bogus/Extensions/Norway/ExtensionsForNorway.cs
+++ b/Source/Bogus/Extensions/Norway/ExtensionsForNorway.cs
@@ -15,7 +15,7 @@ public static class ExtensionsForNorway
       const string Key = nameof(ExtensionsForNorway) + "Fødselsnummer";
       if (p.context.TryGetValue(Key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       /*

--- a/Source/Bogus/Extensions/Poland/ExtensionsForPoland.cs
+++ b/Source/Bogus/Extensions/Poland/ExtensionsForPoland.cs
@@ -22,7 +22,7 @@ public static class ExtensionsForPoland
       const string Key = nameof(ExtensionsForPoland) + nameof(Pesel);
       if (person.context.TryGetValue(Key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       return new StringBuilder()

--- a/Source/Bogus/Extensions/Portugal/ExtensionsForPortugal.cs
+++ b/Source/Bogus/Extensions/Portugal/ExtensionsForPortugal.cs
@@ -20,7 +20,7 @@ public static class ExtensionsForPortugal
       const string Key = nameof(ExtensionsForPortugal) + "NIF";
       if (p.context.TryGetValue(Key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       var id = new[] {p.Random.ArrayElement(TaxNumberGenerator.NifIdentify)};

--- a/Source/Bogus/Extensions/Romania/ExtensionsForRomania.cs
+++ b/Source/Bogus/Extensions/Romania/ExtensionsForRomania.cs
@@ -37,7 +37,7 @@ public static class ExtensionsForRomania
 
       if (p.context.TryGetValue(Key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       var randomizer = p.Random;

--- a/Source/Bogus/Extensions/Sweden/ExtensionsForSweden.cs
+++ b/Source/Bogus/Extensions/Sweden/ExtensionsForSweden.cs
@@ -18,7 +18,7 @@ public static class ExtensionsForSweden
       const string key = nameof(ExtensionsForSweden) + nameof(Personnummer);
       if (person.context.TryGetValue(key, out var value))
       {
-         return value as string;
+         return (string)value;
       }
 
       /*
@@ -55,7 +55,7 @@ public static class ExtensionsForSweden
       const string key = nameof(ExtensionsForSweden) + nameof(Samordningsnummer);
       if( person.context.TryGetValue(key, out var value) )
       {
-         return value as string;
+         return (string)value;
       }
 
       /*

--- a/Source/Bogus/Extensions/UnitedKingdom/ExtensionsForUnitedKingdom.cs
+++ b/Source/Bogus/Extensions/UnitedKingdom/ExtensionsForUnitedKingdom.cs
@@ -65,7 +65,7 @@ public static class ExtensionsForUnitedKingdom
    /// </summary>
    public static string CountryOfUnitedKingdom(this Address address)
    {
-      var countries = Database.Get(nameof(address), "uk_country", "en_GB") as BArray;
+      var countries = (BArray)Database.Get(nameof(address), "uk_country", "en_GB");
       return address.Random.ArrayElement(countries);
    }
 

--- a/Source/Bogus/Extensions/UnitedStates/ExtensionsForUnitedStates.cs
+++ b/Source/Bogus/Extensions/UnitedStates/ExtensionsForUnitedStates.cs
@@ -16,7 +16,7 @@ public static class ExtensionsForUnitedStates
 
       if( p.context.TryGetValue(Key, out var value) )
       {
-         return value as string;
+         return (string)value;
       }
 
       var randomizer = p.Random;

--- a/Source/Bogus/Faker[T].Extensions.cs
+++ b/Source/Bogus/Faker[T].Extensions.cs
@@ -17,7 +17,7 @@ public static class ExtensionsForFakerT
    /// <param name="max">Maximum number of T objects to create. Inclusive.</param>
    public static List<T> GenerateBetween<T>(this Faker<T> faker, int min, int max, string ruleSets = null) where T : class
    {
-      var internals = faker as IFakerTInternal;
+      var internals = (IFakerTInternal)faker;
       var r = internals.FakerHub.Random;
       var n = r.Number(min, max);
       return faker.Generate(n, ruleSets);

--- a/Source/Bogus/Premium/ContextHelper.cs
+++ b/Source/Bogus/Premium/ContextHelper.cs
@@ -8,7 +8,7 @@ public static class ContextHelper
 {
    public static T GetOrSet<T>(string key, Faker f, Func<T> factory) where T : DataSet
    {
-      var context = (f as IHasContext).Context;
+      var context = ((IHasContext)f).Context;
 
       if( context.TryGetValue(key, out var t) )
       {
@@ -16,7 +16,7 @@ public static class ContextHelper
       }
 
       var dataset = factory();
-      var notifier = (f as IHasRandomizer).GetNotifier();
+      var notifier = ((IHasRandomizer)f).GetNotifier();
       notifier.Flow(dataset);
 
       context[key] = dataset;


### PR DESCRIPTION
places where if it isnt that type, it would result in a null ref. so in the case where the type assumption is wrong, it is better to get a helpful exception about incorrect type, than a null ref