### PR TITLE
fix: replace broken placeholder.com service in Images.PlaceholderUrl (#619)

### DIFF
--- a/Source/Bogus.Tests/DataSetTests/ImageTest.cs
+++ b/Source/Bogus.Tests/DataSetTests/ImageTest.cs
@@ -66,10 +66,10 @@ public class ImageTest : SeededTest
    public void can_use_placeholder_url()
    {
       var url = image.PlaceholderUrl(200, 300, "foobar is today", "090", "ddd");
-      url.Should().Be("https://via.placeholder.com/200x300/090/ddd.png?text=foobar%20is%20today");
+      url.Should().Be("https://placehold.co/200x300/090/ddd.png?text=foobar%20is%20today");
 
       url = image.PlaceholderUrl(300, 200);
-      url.Should().Be("https://via.placeholder.com/300x200/cccccc/9c9c9c.png");
+      url.Should().Be("https://placehold.co/300x200/cccccc/9c9c9c.png");
    }
 
    [Fact]

--- a/Source/Bogus/DataSets/Images.cs
+++ b/Source/Bogus/DataSets/Images.cs
@@ -100,7 +100,7 @@ public partial class Images : DataSet
    }
 
    /// <summary>
-   /// Get an image from https://placeholder.com service.
+   /// Get an image from https://placehold.co service.
    /// </summary>
    /// <param name="width">Width of the image.</param>
    /// <param name="height">Height of the image.</param>
@@ -110,7 +110,7 @@ public partial class Images : DataSet
    /// <param name="textColor">HTML color code for the foreground (text) color.</param>
    public string PlaceholderUrl(int width, int height, string text = null, string backColor = "cccccc", string textColor = "9c9c9c", string format = "png")
    {
-      const string Url = "https://via.placeholder.com/";
+      const string Url = "https://placehold.co/";
 
       var sb = new StringBuilder(Url);
 


### PR DESCRIPTION
This PR fixes issue #619.

- Replaced the broken placeholder.com service with placehold.co.
- Updated `Images.PlaceholderUrl` to generate working image URLs.
