### PR TITLE
Adds music and vehicle faker classes to parse method and unit tests

### DIFF
--- a/Source/Bogus.Tests/HandlebarsTests/ArgumentsTest.cs
+++ b/Source/Bogus.Tests/HandlebarsTests/ArgumentsTest.cs
@@ -137,4 +137,38 @@ public class ArgumentsTest : SeededTest
       faker.Parse("{{date.timespan(00:00:25)}}")
          .Should().Be("00:00:15.0880571");
    }
+
+
+
+   [Fact]
+   public void can_parse_vehicle()
+   {
+      var faker = new Faker();
+      var result = faker.Parse("{{vehicle.manufacturer}}");
+      Assert.NotNull(result);
+   }
+
+   [Fact]
+   public void parse_vehicle_returns_expected_value()
+   {
+      var faker = new Faker();
+      var result = faker.Parse("{{vehicle.manufacturer}}");
+      result.Should().Be("Maserati");
+   }
+
+   [Fact]
+   public void can_parse_music()
+   {
+      var faker = new Faker();
+      var result = faker.Parse("{{music.genre}}");
+      Assert.NotNull(result);
+   }
+
+   [Fact]
+   public void parse_music_returns_expected_value()
+   {
+      var faker = new Faker();
+      var result = faker.Parse("{{music.genre}}");
+      result.Should().Be("Hip Hop");
+   }
 }

--- a/Source/Bogus/Faker.cs
+++ b/Source/Bogus/Faker.cs
@@ -92,7 +92,9 @@ public class Faker : ILocaleAware, IHasRandomizer, IHasContext
          this.System,
          this.Commerce,
          this.Database,
-         this.Random);
+         this.Random,
+         this.Music,
+         this.Vehicle);
    }
 
 


### PR DESCRIPTION
These are some small changes taken from my other branch/pull request  "Add Vehicle, Music, and Person to Parse method #602". Since adding the Person class is likely to be more involved, I split the changes as requested.

### Issue/Feature

Faker contains a parse method however it is missing implementations for Vehicle and Music.

### Implimentation

Vehicle:

    Added to list of Mustache Methods passed into Parse method
    Added unit tests to check that values can be returned from parse

Music

    Added to list of Mustache Methods passed into Parse method
    Added unit tests to check that values can be returned from parse
